### PR TITLE
Reconnect Flask backend with frontend

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Werkzeug<3
 SQLAlchemy==2.0.23
 supabase==2.18.1
 psycopg2-binary==2.9.9
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- serve HTML templates from Flask, adding home, login, register and generate routes
- handle missing database gracefully while keeping job submission API
- include python-dotenv dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6b1c5a888832781bf55d46a8b0d15