### PR TITLE
Reconnect Flask backend with frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ gestion des utilisateurs. Pour l'activer :
    export SUPABASE_DB_URL="postgresql://..."  # clé service role
    ```
 
-3. Initialisez la table `profiles` utilisée par le formulaire
+3. Initialisez la table `profiles` (email et mot de passe hashé) utilisée par le formulaire
    d'inscription :
 
    ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Werkzeug<3
 SQLAlchemy==2.0.23
 supabase==2.18.1
 psycopg2-binary==2.9.9
+python-dotenv==1.0.1

--- a/scripts/create_supabase_tables.py
+++ b/scripts/create_supabase_tables.py
@@ -18,8 +18,10 @@ import psycopg2
 
 CREATE_PROFILES = """
 create table if not exists profiles (
-    id uuid references auth.users primary key,
+    id uuid primary key,
     username text,
+    email text unique,
+    password_hash text,
     created_at timestamp with time zone default now()
 );
 """

--- a/src/app.py
+++ b/src/app.py
@@ -1,27 +1,109 @@
 import json
-from flask import Flask, jsonify, request
-import psycopg2
 import os
+import re
+from uuid import uuid4
+
+import psycopg2
+from flask import Flask, jsonify, render_template, request
 from dotenv import load_dotenv
+from werkzeug.security import generate_password_hash
+
 load_dotenv()
 
 
 app = Flask(__name__)
 
 # 🔑 Connexion Postgres (infos depuis Dashboard Supabase -> Database -> Connection info)
-conn = psycopg2.connect(
-    host=os.getenv("SUPABASE_DB_HOST", "db.cryetaumceiljumacrww.supabase.co"),
-    dbname=os.getenv("SUPABASE_DB_NAME", "postgres"),
-    user=os.getenv("SUPABASE_DB_USER", "postgres"),
-    password=os.getenv("SUPABASE_DB_PASSWORD"),  # ⚠️ à définir dans ton .env
-    port=5432,
-    sslmode="require"
-)
+try:
+    conn = psycopg2.connect(
+        host=os.getenv("SUPABASE_DB_HOST", "db.cryetaumceiljumacrww.supabase.co"),
+        dbname=os.getenv("SUPABASE_DB_NAME", "postgres"),
+        user=os.getenv("SUPABASE_DB_USER", "postgres"),
+        password=os.getenv("SUPABASE_DB_PASSWORD"),  # ⚠️ à définir dans ton .env
+        port=5432,
+        sslmode="require",
+    )
+except Exception:
+    # Permet aux tests de s'exécuter sans base disponible
+    conn = None
+
+
+@app.get("/")
+def home():
+    """Page d'accueil HTML avec boutons de connexion et création de compte."""
+    return render_template("index.html")
+
+
+@app.get("/api")
+def index():
+    """Endpoint simple renvoyant un message JSON pour l'API."""
+    return jsonify({"message": "API de génération vidéo"})
+
+
+@app.route("/login", methods=["GET", "POST"])
+def login():
+    """Page de connexion."""
+    if request.method == "POST":
+        return "Login submitted", 200
+    return render_template("login.html")
+
+
+@app.route("/register", methods=["GET", "POST"])
+def register():
+    """Page de création de compte."""
+    if request.method == "POST":
+        data = request.get_json(silent=True) or request.form
+        email = (data.get("email") or "").strip()
+        username = (data.get("username") or "").strip()
+        password = data.get("password") or ""
+
+        # 🔒 Validations de base
+        email_regex = r"^[^@\s]+@[^@\s]+\.[^@\s]+$"
+        if not re.match(email_regex, email):
+            return jsonify({"error": "Invalid email"}), 400
+        if not re.fullmatch(r"[A-Za-z0-9_ ]+", username):
+            return jsonify({"error": "Invalid username"}), 400
+        if len(password) < 8 or not re.search(r"[A-Z]", password) or not re.search(r"\d", password):
+            return jsonify({"error": "Weak password"}), 400
+
+        if conn is None:
+            return jsonify({"error": "Database connection not available"}), 500
+
+        try:
+            hashed = generate_password_hash(password)
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO profiles (id, username, email, password_hash)
+                    VALUES (%s, %s, %s, %s)
+                    RETURNING id
+                    """,
+                    (str(uuid4()), username, email, hashed),
+                )
+                profile_id = cur.fetchone()[0]
+                conn.commit()
+            return jsonify({"id": str(profile_id)}), 201
+        except Exception as e:
+            conn.rollback()
+            return jsonify({"error": str(e)}), 400
+
+    return render_template("register.html")
+
+
+@app.post("/generate")
+def generate_video():
+    data = request.get_json(force=True)
+    prompt = data.get("prompt", "")
+    # Logique de génération IA à implémenter
+    return jsonify({"status": "processing", "prompt": prompt}), 202
 
 
 @app.post("/submit_job")
 def submit_job():
     """Créer un job en base via psycopg2"""
+    if conn is None:
+        return jsonify({"error": "Database connection not available"}), 500
+
     data = request.get_json(force=True)
     user_id = data.get("user_id")
     prompt = data.get("prompt", "")
@@ -52,11 +134,14 @@ def submit_job():
 @app.get("/list_jobs/<user_id>")
 def list_jobs(user_id):
     """Lister les jobs pour un user"""
+    if conn is None:
+        return jsonify({"error": "Database connection not available"}), 500
+
     try:
         with conn.cursor() as cur:
             cur.execute(
                 "SELECT id, prompt, status, submitted_at FROM jobs WHERE user_id = %s ORDER BY submitted_at DESC",
-                (user_id,)
+                (user_id,),
             )
             rows = cur.fetchall()
         jobs = [

--- a/src/tests/test_app.py
+++ b/src/tests/test_app.py
@@ -50,3 +50,21 @@ def test_register_page():
     page = resp.data.decode("utf-8")
     assert "Créer un compte" in page
     assert "<form" in page
+
+
+def test_register_invalid_email():
+    client = app.test_client()
+    resp = client.post("/register", json={"email": "invalid", "username": "User", "password": "Password1"})
+    assert resp.status_code == 400
+
+
+def test_register_invalid_password():
+    client = app.test_client()
+    resp = client.post("/register", json={"email": "user@example.com", "username": "User", "password": "short"})
+    assert resp.status_code == 400
+
+
+def test_register_invalid_username():
+    client = app.test_client()
+    resp = client.post("/register", json={"email": "user@example.com", "username": "Bad!User", "password": "Password1"})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- serve HTML templates from Flask, adding home, login, register and generate routes
- handle missing database gracefully while keeping job submission API
- secure registration: validate email, username and password before inserting profile into Supabase
- update Supabase setup script and docs for storing hashed credentials

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6b1c5a888832781bf55d46a8b0d15