### PR TITLE
feat: track fal.ai render files

### DIFF
--- a/scripts/create_supabase_tables.py
+++ b/scripts/create_supabase_tables.py
@@ -26,6 +26,15 @@ create table if not exists profiles (
 );
 """
 
+CREATE_FILES = """
+create table if not exists files (
+    id bigserial primary key,
+    url text not null,
+    bucket text,
+    created_at timestamp with time zone default now()
+);
+"""
+
 def main() -> None:
     db_url = os.getenv("SUPABASE_DB_URL")
     if not db_url:
@@ -34,6 +43,7 @@ def main() -> None:
     try:
         with conn, conn.cursor() as cur:
             cur.execute(CREATE_PROFILES)
+            cur.execute(CREATE_FILES)
     finally:
         conn.close()
 

--- a/src/tests/test_worker.py
+++ b/src/tests/test_worker.py
@@ -1,0 +1,74 @@
+import os
+import sys
+
+# Ajoute le répertoire parent au PYTHONPATH pour importer worker
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+# Fournit un module Celery factice pour les tests
+class DummyCelery:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def task(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+sys.modules.setdefault("celery", type("celery", (), {"Celery": DummyCelery}))
+
+class DummyFalClient:
+    def subscribe(self, *args, **kwargs):
+        return {}
+
+sys.modules.setdefault("fal_client", DummyFalClient())
+import worker as worker_module
+
+
+def test_process_video_job_inserts_file(monkeypatch):
+    executed = []
+
+    class DummyCursor:
+        def __init__(self):
+            self.fetchone_result = None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def execute(self, sql, params=None):
+            executed.append((sql.strip(), params))
+            if sql.strip().startswith("SELECT prompt"):  # return prompt for job
+                self.fetchone_result = ("hello",)
+            elif sql.strip().startswith("INSERT INTO files"):
+                self.fetchone_result = (42,)
+            else:
+                self.fetchone_result = None
+
+        def fetchone(self):
+            return self.fetchone_result
+
+    class DummyConn:
+        def cursor(self):
+            return DummyCursor()
+
+        def commit(self):
+            pass
+
+        def rollback(self):
+            pass
+
+    def fake_subscribe(*args, **kwargs):
+        return {"video": {"url": "http://example.com/video.mp4"}}
+
+    monkeypatch.setattr(worker_module, "conn", DummyConn())
+    monkeypatch.setattr(worker_module.fal_client, "subscribe", fake_subscribe)
+
+    worker_module.process_video_job(1)
+
+    # Vérifie que l'insertion dans files a eu lieu
+    assert any("INSERT INTO files" in sql for sql, _ in executed)
+    # Vérifie que l'insertion dans videos utilise le file_id obtenu
+    videos_exec = [params for sql, params in executed if "INSERT INTO videos" in sql]
+    assert videos_exec and 42 in videos_exec[0]


### PR DESCRIPTION
## Summary
- store fal.ai video URL in `files` table and reference it from generated videos
- create `files` table alongside existing Supabase schema
- cover file tracking with a unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6cb3195048327967d4d9241a0da04