### PR TITLE
feat: track fal.ai render files and modernize UI

### DIFF
--- a/scripts/create_supabase_tables.py
+++ b/scripts/create_supabase_tables.py
@@ -26,6 +26,15 @@ create table if not exists profiles (
 );
 """
 
+CREATE_FILES = """
+create table if not exists files (
+    id bigserial primary key,
+    url text not null,
+    bucket text,
+    created_at timestamp with time zone default now()
+);
+"""
+
 def main() -> None:
     db_url = os.getenv("SUPABASE_DB_URL")
     if not db_url:
@@ -34,6 +43,7 @@ def main() -> None:
     try:
         with conn, conn.cursor() as cur:
             cur.execute(CREATE_PROFILES)
+            cur.execute(CREATE_FILES)
     finally:
         conn.close()
 

--- a/src/app.py
+++ b/src/app.py
@@ -156,6 +156,12 @@ def register():
     return render_template("register.html")
 
 
+@app.get("/generate")
+def generate_page():
+    """Page de génération vidéo"""
+    return render_template("generate.html")
+
+
 @app.post("/generate")
 def generate_video():
     """Simule la génération vidéo IA"""

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -3,52 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <title>{% block title %}{% endblock %}</title>
-  <style>
-    body {
-      margin: 0;
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background: radial-gradient(circle at top left, #0f0c29, #302b63, #24243e);
-      color: #fff;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      height: 100vh;
-    }
-    .container {
-      text-align: center;
-    }
-    h1 {
-      margin-bottom: 2rem;
-      text-shadow: 0 0 10px #00e6e6;
-    }
-    .btn {
-      padding: 1rem 2rem;
-      margin: 0 1rem;
-      border: none;
-      border-radius: 4px;
-      font-size: 1rem;
-      cursor: pointer;
-      color: #fff;
-      background: linear-gradient(45deg, #00e6e6, #0073e6);
-      box-shadow: 0 0 15px #00e6e6;
-      transition: transform 0.2s;
-    }
-    .btn:hover {
-      transform: scale(1.05);
-    }
-    .input {
-      padding: 0.8rem 1rem;
-      margin: 0.5rem 0;
-      border: none;
-      border-radius: 4px;
-      width: 100%;
-      max-width: 300px;
-    }
-  </style>
+  <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-  <div class="container">
+<body class="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-black text-slate-100">
+  <nav class="bg-slate-900/80 backdrop-blur sticky top-0">
+    <div class="max-w-6xl mx-auto flex items-center justify-between p-4">
+      <a href="/" class="text-xl font-semibold tracking-wide">AI Video</a>
+      <div class="space-x-4 text-sm">
+        <a href="/generate" class="hover:text-teal-300">Generate</a>
+        <a href="/login" class="hover:text-teal-300">Login</a>
+        <a href="/register" class="hover:text-teal-300">Register</a>
+      </div>
+    </div>
+  </nav>
+  <main class="max-w-6xl mx-auto p-6">
     {% block content %}{% endblock %}
-  </div>
+  </main>
 </body>
 </html>

--- a/src/templates/generate.html
+++ b/src/templates/generate.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block title %}Generate Video{% endblock %}
+{% block content %}
+<div class="max-w-2xl mx-auto space-y-6">
+  <h1 class="text-3xl font-semibold text-center">Generate Video</h1>
+  <form id="gen-form" class="space-y-4">
+    <input id="prompt" class="w-full px-4 py-2 rounded bg-slate-900 border border-slate-700 focus:outline-none focus:ring-2 focus:ring-teal-500" type="text" placeholder="Enter prompt" required />
+    <button class="w-full py-2 rounded bg-teal-500 hover:bg-teal-400 text-slate-900 font-semibold" type="submit">Generate</button>
+  </form>
+  <pre id="result" class="bg-slate-900 p-4 rounded text-sm"></pre>
+</div>
+<script>
+document.getElementById('gen-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const prompt = document.getElementById('prompt').value;
+  const res = await fetch('/generate', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({prompt})
+  });
+  const data = await res.json();
+  document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+});
+</script>
+{% endblock %}

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,7 +1,13 @@
 {% extends 'base.html' %}
 {% block title %}AI Video Generator{% endblock %}
 {% block content %}
-<h1>Générateur de Vidéo IA</h1>
-<button class="btn" onclick="location.href='/login'">Connexion</button>
-<button class="btn" onclick="location.href='/register'">Créer un compte</button>
+<section class="text-center py-24">
+  <h1 class="text-5xl font-bold mb-6 tracking-tight">Veo 3 Fast [Image to Video]</h1>
+  <p class="mb-8 text-lg text-slate-300">Generate videos from your image prompts using Veo 3 fast.</p>
+  <div class="space-x-4">
+    <a href="/generate" class="px-6 py-3 rounded-md bg-teal-500 hover:bg-teal-400 text-slate-900 font-semibold">Essayer</a>
+    <a href="/login" class="px-6 py-3 rounded-md border border-teal-500 text-teal-400 hover:bg-teal-500/10">Connexion</a>
+    <a href="/register" class="px-6 py-3 rounded-md border border-teal-500 text-teal-400 hover:bg-teal-500/10">Créer un compte</a>
+  </div>
+</section>
 {% endblock %}

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -1,59 +1,12 @@
-<!DOCTYPE html>
-<html lang="fr">
-<head>
-  <meta charset="UTF-8" />
-  <title>Connexion</title>
-  <style>
-    body {
-      margin: 0;
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background: radial-gradient(circle at top left, #0f0c29, #302b63, #24243e);
-      color: #fff;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      height: 100vh;
-    }
-    .container {
-      text-align: center;
-    }
-    h1 {
-      margin-bottom: 2rem;
-      text-shadow: 0 0 10px #00e6e6;
-    }
-    .input {
-      padding: 0.8rem 1rem;
-      margin: 0.5rem 0;
-      border: none;
-      border-radius: 4px;
-      width: 100%;
-      max-width: 300px;
-    }
-    .btn {
-      padding: 1rem 2rem;
-      margin-top: 1rem;
-      border: none;
-      border-radius: 4px;
-      font-size: 1rem;
-      cursor: pointer;
-      color: #fff;
-      background: linear-gradient(45deg, #00e6e6, #0073e6);
-      box-shadow: 0 0 15px #00e6e6;
-      transition: transform 0.2s;
-    }
-    .btn:hover {
-      transform: scale(1.05);
-    }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Connexion</h1>
-    <form method="post">
-      <input class="input" type="email" name="email" placeholder="Email" required />
-      <input class="input" type="password" name="password" placeholder="Mot de passe" required />
-      <button class="btn" type="submit">Se connecter</button>
-    </form>
-  </div>
-</body>
-</html>
+{% extends 'base.html' %}
+{% block title %}Connexion{% endblock %}
+{% block content %}
+<div class="max-w-md mx-auto bg-slate-800/60 p-8 rounded-lg shadow">
+  <h1 class="text-2xl font-semibold mb-6 text-center">Connexion</h1>
+  <form method="post" class="space-y-4">
+    <input class="w-full px-4 py-2 rounded bg-slate-900 border border-slate-700 focus:outline-none focus:ring-2 focus:ring-teal-500" type="email" name="email" placeholder="Email" required />
+    <input class="w-full px-4 py-2 rounded bg-slate-900 border border-slate-700 focus:outline-none focus:ring-2 focus:ring-teal-500" type="password" name="password" placeholder="Mot de passe" required />
+    <button class="w-full py-2 rounded bg-teal-500 hover:bg-teal-400 text-slate-900 font-semibold" type="submit">Se connecter</button>
+  </form>
+</div>
+{% endblock %}

--- a/src/templates/register.html
+++ b/src/templates/register.html
@@ -1,11 +1,13 @@
 {% extends 'base.html' %}
 {% block title %}Créer un compte{% endblock %}
 {% block content %}
-<h1>Créer un compte</h1>
-<form method="post">
-  <input class="input" type="text" name="username" placeholder="Nom d'utilisateur" required />
-  <input class="input" type="email" name="email" placeholder="Email" required />
-  <input class="input" type="password" name="password" placeholder="Mot de passe" required />
-  <button class="btn" type="submit">S'inscrire</button>
-</form>
+<div class="max-w-md mx-auto bg-slate-800/60 p-8 rounded-lg shadow">
+  <h1 class="text-2xl font-semibold mb-6 text-center">Créer un compte</h1>
+  <form method="post" class="space-y-4">
+    <input class="w-full px-4 py-2 rounded bg-slate-900 border border-slate-700 focus:outline-none focus:ring-2 focus:ring-teal-500" type="text" name="username" placeholder="Nom d'utilisateur" required />
+    <input class="w-full px-4 py-2 rounded bg-slate-900 border border-slate-700 focus:outline-none focus:ring-2 focus:ring-teal-500" type="email" name="email" placeholder="Email" required />
+    <input class="w-full px-4 py-2 rounded bg-slate-900 border border-slate-700 focus:outline-none focus:ring-2 focus:ring-teal-500" type="password" name="password" placeholder="Mot de passe" required />
+    <button class="w-full py-2 rounded bg-teal-500 hover:bg-teal-400 text-slate-900 font-semibold" type="submit">S'inscrire</button>
+  </form>
+</div>
 {% endblock %}

--- a/src/tests/test_worker.py
+++ b/src/tests/test_worker.py
@@ -1,0 +1,74 @@
+import os
+import sys
+
+# Ajoute le répertoire parent au PYTHONPATH pour importer worker
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+# Fournit un module Celery factice pour les tests
+class DummyCelery:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def task(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+sys.modules.setdefault("celery", type("celery", (), {"Celery": DummyCelery}))
+
+class DummyFalClient:
+    def subscribe(self, *args, **kwargs):
+        return {}
+
+sys.modules.setdefault("fal_client", DummyFalClient())
+import worker as worker_module
+
+
+def test_process_video_job_inserts_file(monkeypatch):
+    executed = []
+
+    class DummyCursor:
+        def __init__(self):
+            self.fetchone_result = None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def execute(self, sql, params=None):
+            executed.append((sql.strip(), params))
+            if sql.strip().startswith("SELECT prompt"):  # return prompt for job
+                self.fetchone_result = ("hello",)
+            elif sql.strip().startswith("INSERT INTO files"):
+                self.fetchone_result = (42,)
+            else:
+                self.fetchone_result = None
+
+        def fetchone(self):
+            return self.fetchone_result
+
+    class DummyConn:
+        def cursor(self):
+            return DummyCursor()
+
+        def commit(self):
+            pass
+
+        def rollback(self):
+            pass
+
+    def fake_subscribe(*args, **kwargs):
+        return {"video": {"url": "http://example.com/video.mp4"}}
+
+    monkeypatch.setattr(worker_module, "conn", DummyConn())
+    monkeypatch.setattr(worker_module.fal_client, "subscribe", fake_subscribe)
+
+    worker_module.process_video_job(1)
+
+    # Vérifie que l'insertion dans files a eu lieu
+    assert any("INSERT INTO files" in sql for sql, _ in executed)
+    # Vérifie que l'insertion dans videos utilise le file_id obtenu
+    videos_exec = [params for sql, params in executed if "INSERT INTO videos" in sql]
+    assert videos_exec and 42 in videos_exec[0]


### PR DESCRIPTION
## Summary
- store fal.ai video URL in `files` table and reference it from generated videos
- create `files` table alongside existing Supabase schema
- cover file tracking with a unit test
- apply a Tailwind-based design with shared navigation across HTML templates
- add a generation page for submitting prompts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6cb3195048327967d4d9241a0da04