### PR TITLE
Require login for video generation and integrate fal pipeline

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -10,9 +10,12 @@
     <div class="max-w-6xl mx-auto flex items-center justify-between p-4">
       <a href="/" class="text-xl font-semibold tracking-wide">AI Video</a>
       <div class="space-x-4 text-sm">
+        {% if session.get('user_id') %}
         <a href="/generate" class="hover:text-teal-300">Generate</a>
+        {% else %}
         <a href="/login" class="hover:text-teal-300">Login</a>
         <a href="/register" class="hover:text-teal-300">Register</a>
+        {% endif %}
       </div>
     </div>
   </nav>

--- a/src/templates/generate.html
+++ b/src/templates/generate.html
@@ -5,18 +5,25 @@
   <h1 class="text-3xl font-semibold text-center">Generate Video</h1>
   <form id="gen-form" class="space-y-4">
     <input id="prompt" class="w-full px-4 py-2 rounded bg-slate-900 border border-slate-700 focus:outline-none focus:ring-2 focus:ring-teal-500" type="text" placeholder="Enter prompt" required />
+    <input id="image-url" class="w-full px-4 py-2 rounded bg-slate-900 border border-slate-700 focus:outline-none focus:ring-2 focus:ring-teal-500" type="text" placeholder="Image URL" required />
     <button class="w-full py-2 rounded bg-teal-500 hover:bg-teal-400 text-slate-900 font-semibold" type="submit">Generate</button>
   </form>
   <pre id="result" class="bg-slate-900 p-4 rounded text-sm"></pre>
 </div>
 <script>
+const USER_ID = {{ user_id | tojson }};
 document.getElementById('gen-form').addEventListener('submit', async (e) => {
   e.preventDefault();
   const prompt = document.getElementById('prompt').value;
-  const res = await fetch('/generate', {
+  const imageUrl = document.getElementById('image-url').value;
+  const res = await fetch('/submit_job', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({prompt})
+    body: JSON.stringify({
+      user_id: USER_ID,
+      prompt,
+      params: { image_url: imageUrl }
+    })
   });
   const data = await res.json();
   document.getElementById('result').textContent = JSON.stringify(data, null, 2);

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -5,9 +5,12 @@
   <h1 class="text-5xl font-bold mb-6 tracking-tight">Veo 3 Fast [Image to Video]</h1>
   <p class="mb-8 text-lg text-slate-300">Generate videos from your image prompts using Veo 3 fast.</p>
   <div class="space-x-4">
+    {% if session.get('user_id') %}
     <a href="/generate" class="px-6 py-3 rounded-md bg-teal-500 hover:bg-teal-400 text-slate-900 font-semibold">Essayer</a>
+    {% else %}
     <a href="/login" class="px-6 py-3 rounded-md border border-teal-500 text-teal-400 hover:bg-teal-500/10">Connexion</a>
     <a href="/register" class="px-6 py-3 rounded-md border border-teal-500 text-teal-400 hover:bg-teal-500/10">Créer un compte</a>
+    {% endif %}
   </div>
 </section>
 {% endblock %}

--- a/src/tests/test_app.py
+++ b/src/tests/test_app.py
@@ -35,6 +35,24 @@ def test_generate_video():
     assert data["prompt"] == "test"
 
 
+def test_generate_requires_login():
+    client = app.test_client()
+    resp = client.get("/generate")
+    assert resp.status_code == 302
+    assert "/login" in resp.headers["Location"]
+
+
+def test_generate_page_has_image_field():
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["user_id"] = "u1"
+
+    resp = client.get("/generate")
+    assert resp.status_code == 200
+    page = resp.data.decode("utf-8")
+    assert 'id="image-url"' in page
+
+
 def test_login_page():
     client = app.test_client()
     resp = client.get("/login")

--- a/src/tests/test_worker.py
+++ b/src/tests/test_worker.py
@@ -17,8 +17,9 @@ class DummyCelery:
 sys.modules.setdefault("celery", type("celery", (), {"Celery": DummyCelery}))
 
 class DummyFalClient:
-    def subscribe(self, *args, **kwargs):
-        return {}
+    def __init__(self):
+        self.submit = lambda *args, **kwargs: None
+        self.result = lambda *args, **kwargs: {}
 
 sys.modules.setdefault("fal_client", DummyFalClient())
 import worker as worker_module
@@ -26,6 +27,7 @@ import worker as worker_module
 
 def test_process_video_job_inserts_file(monkeypatch):
     executed = []
+    submitted = {}
 
     class DummyCursor:
         def __init__(self):
@@ -39,8 +41,11 @@ def test_process_video_job_inserts_file(monkeypatch):
 
         def execute(self, sql, params=None):
             executed.append((sql.strip(), params))
-            if sql.strip().startswith("SELECT prompt"):  # return prompt for job
-                self.fetchone_result = ("hello",)
+            if sql.strip().startswith("SELECT prompt"):
+                self.fetchone_result = (
+                    "hello",
+                    '{"image_url": "http://example.com/img.png"}',
+                )
             elif sql.strip().startswith("INSERT INTO files"):
                 self.fetchone_result = (42,)
             else:
@@ -59,11 +64,20 @@ def test_process_video_job_inserts_file(monkeypatch):
         def rollback(self):
             pass
 
-    def fake_subscribe(*args, **kwargs):
+    class DummyHandle:
+        request_id = "abc123"
+
+    def fake_submit(*args, **kwargs):
+        submitted["args"] = args
+        submitted["kwargs"] = kwargs
+        return DummyHandle()
+
+    def fake_result(*args, **kwargs):
         return {"video": {"url": "http://example.com/video.mp4"}}
 
     monkeypatch.setattr(worker_module, "conn", DummyConn())
-    monkeypatch.setattr(worker_module.fal_client, "subscribe", fake_subscribe)
+    monkeypatch.setattr(worker_module.fal_client, "submit", fake_submit)
+    monkeypatch.setattr(worker_module.fal_client, "result", fake_result)
 
     worker_module.process_video_job(1)
 
@@ -72,3 +86,12 @@ def test_process_video_job_inserts_file(monkeypatch):
     # Vérifie que l'insertion dans videos utilise le file_id obtenu
     videos_exec = [params for sql, params in executed if "INSERT INTO videos" in sql]
     assert videos_exec and 42 in videos_exec[0]
+    # Vérifie que l'ID externe a été enregistré avec la bonne valeur
+    updates = [params for sql, params in executed if "UPDATE jobs" in sql]
+    assert updates and "abc123" in updates[0]
+    # Vérifie que fal_client.submit reçoit le prompt et l'image
+    assert submitted["kwargs"]["arguments"]["prompt"] == "hello"
+    assert (
+        submitted["kwargs"]["arguments"]["image_url"]
+        == "http://example.com/img.png"
+    )


### PR DESCRIPTION
## Summary
- hide video generation UI behind login using Flask sessions
- replace fal.ai mock with real submit/result flow and store request IDs
- read job params to pass image URL into fal's video endpoint
- update worker tests for new parameter forwarding and external ID tracking
- enable image-to-video job submission on the generate page for authenticated users

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6dc6192c48327b8ed38a0472587bd