### PR TITLE
Add user and admin dashboards

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -92,7 +92,10 @@ def login():
             session["email"] = email
 
             profile_payload = {"user_id": user.id, "email": email}
+            session["role"] = "user"
             if conn:
+                # Ensure the connection is in a clean state before querying
+                conn.rollback()
                 with conn.cursor() as cur:
                     cur.execute(
                         "SELECT role, gpu_minutes_quota FROM profiles WHERE user_id = %s",
@@ -100,15 +103,18 @@ def login():
                     )
                     row = cur.fetchone()
                     if row:
+                        session["role"] = row[0]
                         profile_payload.update(
                             {"role": row[0], "gpu_minutes_quota": row[1]}
                         )
 
             if request.is_json:
                 return jsonify(profile_payload), 200
-            return redirect(url_for("generate_page"))
+            return redirect(url_for("dashboard"))
 
         except Exception as e:
+            if conn:
+                conn.rollback()
             return jsonify({"error": str(e)}), 400
 
     return render_template("login.html")
@@ -146,6 +152,7 @@ def register():
             user_id = user.id
 
             # 2️⃣ Créer le profil applicatif
+            conn.rollback()
             with conn.cursor() as cur:
                 cur.execute(
                     """
@@ -164,6 +171,26 @@ def register():
             return jsonify({"error": str(e)}), 400
 
     return render_template("register.html")
+
+
+@app.get("/dashboard")
+def dashboard():
+    """Tableau de bord utilisateur"""
+    if not session.get("user_id"):
+        return redirect(url_for("login"))
+    return render_template(
+        "dashboard.html",
+        user_id=session["user_id"],
+        role=session.get("role", "user"),
+    )
+
+
+@app.get("/admin")
+def admin_dashboard():
+    """Tableau de bord administrateur"""
+    if session.get("role") != "admin":
+        return redirect(url_for("login"))
+    return render_template("admin_dashboard.html")
 
 
 @app.get("/generate")
@@ -194,6 +221,7 @@ def submit_job():
     params = data.get("params", {})
 
     try:
+        conn.rollback()
         with conn.cursor() as cur:
             cur.execute(
                 """
@@ -232,23 +260,97 @@ def list_jobs(user_id):
         return jsonify({"error": "Database connection not available"}), 500
 
     try:
+        conn.rollback()
         with conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT id, prompt, status, submitted_at
-                FROM jobs
-                WHERE user_id = %s
-                ORDER BY submitted_at DESC
+                SELECT j.id, j.prompt, j.status, j.submitted_at, f.url
+                FROM jobs j
+                LEFT JOIN videos v ON v.job_id = j.id
+                LEFT JOIN files f ON f.id = v.file_id
+                WHERE j.user_id = %s
+                ORDER BY j.submitted_at DESC
                 """,
                 (user_id,),
             )
             rows = cur.fetchall()
         jobs = [
-            {"id": r[0], "prompt": r[1], "status": r[2], "submitted_at": r[3].isoformat()}
+            {
+                "id": r[0],
+                "prompt": r[1],
+                "status": r[2],
+                "submitted_at": r[3].isoformat(),
+                "video_url": r[4],
+            }
             for r in rows
         ]
         return jsonify(jobs)
     except Exception as e:
+        if conn:
+            conn.rollback()
+        return jsonify({"error": str(e)}), 400
+
+
+@app.get("/admin/list_jobs")
+def admin_list_jobs():
+    """Lister tous les jobs (admin)"""
+    if session.get("role") != "admin":
+        return jsonify({"error": "forbidden"}), 403
+    if conn is None:
+        return jsonify({"error": "Database connection not available"}), 500
+    try:
+        conn.rollback()
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT j.id, j.user_id, j.prompt, j.status, j.submitted_at, f.url
+                FROM jobs j
+                LEFT JOIN videos v ON v.job_id = j.id
+                LEFT JOIN files f ON f.id = v.file_id
+                ORDER BY j.submitted_at DESC
+                """
+            )
+            rows = cur.fetchall()
+        jobs = [
+            {
+                "id": r[0],
+                "user_id": r[1],
+                "prompt": r[2],
+                "status": r[3],
+                "submitted_at": r[4].isoformat(),
+                "video_url": r[5],
+            }
+            for r in rows
+        ]
+        return jsonify(jobs)
+    except Exception as e:
+        if conn:
+            conn.rollback()
+        return jsonify({"error": str(e)}), 400
+
+
+@app.get("/admin/list_users")
+def admin_list_users():
+    """Lister les utilisateurs"""
+    if session.get("role") != "admin":
+        return jsonify({"error": "forbidden"}), 403
+    if conn is None:
+        return jsonify({"error": "Database connection not available"}), 500
+    try:
+        conn.rollback()
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT user_id, role, gpu_minutes_quota FROM profiles ORDER BY user_id"
+            )
+            rows = cur.fetchall()
+        users = [
+            {"user_id": r[0], "role": r[1], "gpu_minutes_quota": r[2]}
+            for r in rows
+        ]
+        return jsonify(users)
+    except Exception as e:
+        if conn:
+            conn.rollback()
         return jsonify({"error": str(e)}), 400
 
 

--- a/src/templates/admin_dashboard.html
+++ b/src/templates/admin_dashboard.html
@@ -1,0 +1,72 @@
+{% extends 'base.html' %}
+{% block title %}Admin Dashboard{% endblock %}
+{% block content %}
+<div class="space-y-8">
+  <h1 class="text-3xl font-semibold text-center">Admin Dashboard</h1>
+  <section>
+    <h2 class="text-xl font-semibold mb-2">Jobs</h2>
+    <table class="min-w-full text-sm" id="admin-jobs-table">
+      <thead>
+        <tr class="text-left">
+          <th class="px-2 py-1">ID</th>
+          <th class="px-2 py-1">User</th>
+          <th class="px-2 py-1">Prompt</th>
+          <th class="px-2 py-1">Status</th>
+          <th class="px-2 py-1">Submitted</th>
+          <th class="px-2 py-1">Video</th>
+        </tr>
+      </thead>
+      <tbody id="admin-jobs-body"></tbody>
+    </table>
+  </section>
+  <section>
+    <h2 class="text-xl font-semibold mb-2">Users</h2>
+    <table class="min-w-full text-sm" id="admin-users-table">
+      <thead>
+        <tr class="text-left">
+          <th class="px-2 py-1">User ID</th>
+          <th class="px-2 py-1">Role</th>
+          <th class="px-2 py-1">GPU Minutes</th>
+        </tr>
+      </thead>
+      <tbody id="admin-users-body"></tbody>
+    </table>
+  </section>
+</div>
+<script>
+async function loadAdmin() {
+  const jobsRes = await fetch('/admin/list_jobs');
+  const jobs = await jobsRes.json();
+  const jobsBody = document.getElementById('admin-jobs-body');
+  jobsBody.innerHTML = '';
+  jobs.forEach(j => {
+    let videoLinks = '';
+    if (j.video_url) {
+      videoLinks = `<a href="${j.video_url}" target="_blank" class="text-teal-400">View</a>`;
+    }
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td class="px-2 py-1">${j.id}</td>`+
+                   `<td class="px-2 py-1">${j.user_id}</td>`+
+                   `<td class="px-2 py-1">${j.prompt}</td>`+
+                   `<td class="px-2 py-1">${j.status}</td>`+
+                   `<td class="px-2 py-1">${j.submitted_at}</td>`+
+                   `<td class="px-2 py-1">${videoLinks}</td>`;
+    jobsBody.appendChild(tr);
+  });
+
+  const usersRes = await fetch('/admin/list_users');
+  const users = await usersRes.json();
+  const usersBody = document.getElementById('admin-users-body');
+  usersBody.innerHTML = '';
+  users.forEach(u => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td class="px-2 py-1">${u.user_id}</td>`+
+                   `<td class="px-2 py-1">${u.role}</td>`+
+                   `<td class="px-2 py-1">${u.gpu_minutes_quota}</td>`;
+    usersBody.appendChild(tr);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', loadAdmin);
+</script>
+{% endblock %}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -11,7 +11,10 @@
       <a href="/" class="text-xl font-semibold tracking-wide">AI Video</a>
       <div class="space-x-4 text-sm">
         {% if session.get('user_id') %}
-        <a href="/generate" class="hover:text-teal-300">Generate</a>
+        <a href="/dashboard" class="hover:text-teal-300">Dashboard</a>
+        {% if session.get('role') == 'admin' %}
+        <a href="/admin" class="hover:text-teal-300">Admin</a>
+        {% endif %}
         {% else %}
         <a href="/login" class="hover:text-teal-300">Login</a>
         <a href="/register" class="hover:text-teal-300">Register</a>

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -1,0 +1,61 @@
+{% extends 'base.html' %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<div class="max-w-3xl mx-auto space-y-8">
+  <h1 class="text-3xl font-semibold text-center">Dashboard</h1>
+  <form id="job-form" class="space-y-4">
+    <input id="prompt" class="w-full px-4 py-2 rounded bg-slate-900 border border-slate-700 focus:outline-none focus:ring-2 focus:ring-teal-500" type="text" placeholder="Enter prompt" required />
+    <input id="image-url" class="w-full px-4 py-2 rounded bg-slate-900 border border-slate-700 focus:outline-none focus:ring-2 focus:ring-teal-500" type="text" placeholder="Image URL" required />
+    <button class="w-full py-2 rounded bg-teal-500 hover:bg-teal-400 text-slate-900 font-semibold" type="submit">Submit</button>
+  </form>
+  <table class="min-w-full text-sm" id="jobs-table">
+    <thead>
+      <tr class="text-left">
+        <th class="px-2 py-1">ID</th>
+        <th class="px-2 py-1">Prompt</th>
+        <th class="px-2 py-1">Status</th>
+        <th class="px-2 py-1">Submitted</th>
+        <th class="px-2 py-1">Video</th>
+      </tr>
+    </thead>
+    <tbody id="jobs-body"></tbody>
+  </table>
+</div>
+<script>
+const USER_ID = {{ user_id | tojson }};
+async function loadJobs() {
+  const res = await fetch(`/list_jobs/${USER_ID}`);
+  const jobs = await res.json();
+  const body = document.getElementById('jobs-body');
+  body.innerHTML = '';
+  jobs.forEach(job => {
+    const tr = document.createElement('tr');
+    let videoLinks = '';
+    if (job.video_url) {
+      videoLinks = `<a href="${job.video_url}" target="_blank" class="text-teal-400">View</a>` +
+                   ` <a href="${job.video_url}" download class="text-teal-400 ml-2">Download</a>`;
+    }
+    tr.innerHTML = `<td class="px-2 py-1">${job.id}</td>`+
+                   `<td class="px-2 py-1">${job.prompt}</td>`+
+                   `<td class="px-2 py-1">${job.status}</td>`+
+                   `<td class="px-2 py-1">${job.submitted_at}</td>`+
+                   `<td class="px-2 py-1">${videoLinks}</td>`;
+    body.appendChild(tr);
+  });
+}
+
+document.getElementById('job-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const prompt = document.getElementById('prompt').value;
+  const imageUrl = document.getElementById('image-url').value;
+  await fetch('/submit_job', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({ user_id: USER_ID, prompt, params: { image_url: imageUrl } })
+  });
+  loadJobs();
+});
+
+document.addEventListener('DOMContentLoaded', loadJobs);
+</script>
+{% endblock %}

--- a/worker.py
+++ b/worker.py
@@ -47,6 +47,8 @@ def process_video_job(job_id: int) -> None:
         return
 
     try:
+        # Clear any previous failed transaction
+        conn.rollback()
         # Récupère le prompt et les paramètres (ex: image_url) du job
         with conn.cursor() as cur:
             cur.execute(


### PR DESCRIPTION
## Summary
- Add user dashboard to submit video jobs and view results
- Provide admin dashboard with global job and user monitoring
- Track user roles in session and expose job/video data via new API endpoints
- Reset PostgreSQL connection state before queries and after errors to avoid aborted transactions during login

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6e759354883278daf7c930ab6bf6f