### PR TITLE
Fix duplicate admin routes and add logout functionality

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -120,6 +120,13 @@ def login():
     return render_template("login.html")
 
 
+@app.get("/logout")
+def logout():
+    """Déconnexion utilisateur"""
+    session.clear()
+    return redirect(url_for("login"))
+
+
 @app.route("/register", methods=["GET", "POST"])
 def register():
     """Inscription utilisateur"""
@@ -351,63 +358,6 @@ def admin_list_users():
     except Exception as e:
         if conn:
             conn.rollback()
-        return jsonify({"error": str(e)}), 400
-
-
-@app.get("/admin/list_jobs")
-def admin_list_jobs():
-    """Lister tous les jobs (admin)"""
-    if session.get("role") != "admin":
-        return jsonify({"error": "forbidden"}), 403
-    if conn is None:
-        return jsonify({"error": "Database connection not available"}), 500
-    try:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT j.id, j.user_id, j.prompt, j.status, j.submitted_at, f.url
-                FROM jobs j
-                LEFT JOIN videos v ON v.job_id = j.id
-                LEFT JOIN files f ON f.id = v.file_id
-                ORDER BY j.submitted_at DESC
-                """
-            )
-            rows = cur.fetchall()
-        jobs = [
-            {
-                "id": r[0],
-                "user_id": r[1],
-                "prompt": r[2],
-                "status": r[3],
-                "submitted_at": r[4].isoformat(),
-                "video_url": r[5],
-            }
-            for r in rows
-        ]
-        return jsonify(jobs)
-    except Exception as e:
-        return jsonify({"error": str(e)}), 400
-
-
-@app.get("/admin/list_users")
-def admin_list_users():
-    """Lister les utilisateurs"""
-    if session.get("role") != "admin":
-        return jsonify({"error": "forbidden"}), 403
-    if conn is None:
-        return jsonify({"error": "Database connection not available"}), 500
-    try:
-        with conn.cursor() as cur:
-            cur.execute(
-                "SELECT user_id, role, gpu_minutes_quota FROM profiles ORDER BY user_id"
-            )
-            rows = cur.fetchall()
-        users = [
-            {"user_id": r[0], "role": r[1], "gpu_minutes_quota": r[2]}
-            for r in rows
-        ]
-        return jsonify(users)
-    except Exception as e:
         return jsonify({"error": str(e)}), 400
 
 

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -15,6 +15,7 @@
         {% if session.get('role') == 'admin' %}
         <a href="/admin" class="hover:text-teal-300">Admin</a>
         {% endif %}
+        <a href="/logout" class="hover:text-teal-300">Logout</a>
         {% else %}
         <a href="/login" class="hover:text-teal-300">Login</a>
         <a href="/register" class="hover:text-teal-300">Register</a>

--- a/src/tests/test_app.py
+++ b/src/tests/test_app.py
@@ -152,3 +152,17 @@ def test_register_success(monkeypatch):
         "email": "user@example.com",
         "password": "Password1",
     }
+
+
+def test_logout_clears_session():
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["user_id"] = "u1"
+        sess["role"] = "user"
+
+    resp = client.get("/logout")
+    assert resp.status_code == 302
+    assert "/login" in resp.headers["Location"]
+
+    with client.session_transaction() as sess:
+        assert not sess


### PR DESCRIPTION
## Summary
- remove duplicate `/admin/list_jobs` and `/admin/list_users` endpoints that caused Flask assertion errors
- add `/logout` route clearing session and new navigation link
- cover logout with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6f92c147c8327a7cda31d06598f95