### PR TITLE
Add fal.ai integration with scheduler, admin guard, and metrics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ python-dotenv==1.0.1
 supabase==2.3.1
 celery==5.3.6
 fal-client==0.7.0
+APScheduler==3.10.4
+prometheus_client==0.19.0
+requests==2.31.0

--- a/src/fal_client.py
+++ b/src/fal_client.py
@@ -1,0 +1,61 @@
+import os
+import requests
+
+FAL_BASE = "https://api.fal.ai"
+FAL_KEY = os.getenv("FAL_KEY")
+
+
+def _headers(json: bool = True):
+    headers = {"Authorization": f"Bearer {FAL_KEY}"}
+    if json:
+        headers["Content-Type"] = "application/json"
+    return headers
+
+
+def submit_text2video(model_id: str, prompt: str, webhook_url: str | None = None) -> str:
+    payload: dict[str, object] = {"input": {"prompt": prompt}}
+    if webhook_url:
+        payload["webhookUrl"] = webhook_url
+    r = requests.post(
+        f"{FAL_BASE}/models/{model_id}/api/queue/submit",
+        headers=_headers(),
+        json=payload,
+        timeout=30,
+    )
+    r.raise_for_status()
+    data = r.json()
+    return data.get("request_id") or data.get("id")
+
+
+def get_status(model_id: str, request_id: str) -> dict:
+    r = requests.get(
+        f"{FAL_BASE}/models/{model_id}/api/queue/status",
+        headers=_headers(False),
+        params={"requestId": request_id},
+        timeout=20,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def get_result(model_id: str, request_id: str) -> dict:
+    r = requests.get(
+        f"{FAL_BASE}/models/{model_id}/api/queue/result",
+        headers=_headers(False),
+        params={"requestId": request_id},
+        timeout=30,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+# Backwards compatibility helpers used by worker.py tests
+def submit(model_id: str, arguments: dict):  # pragma: no cover - simple wrapper
+    prompt = arguments.get("prompt", "")
+    webhook_url = arguments.get("webhook_url")
+    req_id = submit_text2video(model_id, prompt, webhook_url)
+    return type("Handle", (), {"request_id": req_id})()
+
+
+def result(model_id: str, request_id: str) -> dict:  # pragma: no cover - simple wrapper
+    return get_result(model_id, request_id)

--- a/src/tests/test_app.py
+++ b/src/tests/test_app.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 # Ajoute le répertoire parent au PYTHONPATH pour import local
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import app as app_module
 from app import app  # type: ignore

--- a/src/tests/test_fal.py
+++ b/src/tests/test_fal.py
@@ -1,0 +1,123 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import app as app_module
+from app import app, _sync_fal_jobs  # type: ignore
+
+
+def test_submit_job_fal(monkeypatch):
+    client = app.test_client()
+
+    class DummyCursor:
+        def __init__(self, history):
+            self.history = history
+            self.fetchone_result = None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def execute(self, sql, params=None):
+            self.history.append((sql, params))
+            if "RETURNING id" in sql:
+                self.fetchone_result = (1,)
+            else:
+                self.fetchone_result = None
+
+        def fetchone(self):
+            return self.fetchone_result
+
+    class DummyConn:
+        def __init__(self):
+            self.history = []
+
+        def cursor(self):
+            return DummyCursor(self.history)
+
+        def commit(self):
+            pass
+
+        def rollback(self):
+            pass
+
+    dummy_conn = DummyConn()
+    monkeypatch.setattr(app_module, "conn", dummy_conn)
+    monkeypatch.setattr(app_module, "submit_text2video", lambda *a, **k: "req_123")
+
+    resp = client.post("/submit_job_fal", json={"user_id": 1, "prompt": "hello"})
+    assert resp.status_code == 202
+    data = resp.get_json()
+    assert data["external_job_id"] == "req_123"
+    assert any("INSERT INTO jobs" in sql for sql, _ in dummy_conn.history)
+    assert any("UPDATE jobs SET external_job_id" in sql for sql, _ in dummy_conn.history)
+
+
+def test_scheduler_sync_success(monkeypatch):
+    class DummyCursor:
+        def __init__(self, history):
+            self.history = history
+            self.fetchall_result = []
+            self.fetchone_result = None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def execute(self, sql, params=None):
+            self.history.append((sql, params))
+            if "SELECT id, external_job_id" in sql:
+                self.fetchall_result = [(1, "req_123", "model")]
+            elif "SELECT user_id FROM jobs" in sql:
+                self.fetchone_result = (42,)
+            else:
+                self.fetchall_result = []
+                self.fetchone_result = None
+
+        def fetchall(self):
+            return self.fetchall_result
+
+        def fetchone(self):
+            return self.fetchone_result
+
+    class DummyConn:
+        def __init__(self):
+            self.history = []
+
+        def cursor(self):
+            return DummyCursor(self.history)
+
+        def commit(self):
+            pass
+
+        def rollback(self):
+            pass
+
+    dummy_conn = DummyConn()
+    monkeypatch.setattr(app_module, "conn", dummy_conn)
+    monkeypatch.setattr(app_module, "get_status", lambda *a, **k: {"status": "SUCCESS"})
+    monkeypatch.setattr(app_module, "get_result", lambda *a, **k: {"video": {"url": "http://v"}})
+
+    _sync_fal_jobs()
+    assert any("INSERT INTO videos" in sql for sql, _ in dummy_conn.history)
+    assert any("status='succeeded'" in sql for sql, _ in dummy_conn.history)
+
+
+def test_admin_guard():
+    client = app.test_client()
+    resp = client.get("/admin/list_jobs")
+    assert resp.status_code == 403
+
+
+def test_metrics_endpoint():
+    client = app.test_client()
+    client.get("/api")
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+    assert "flask_http_requests_total" in body


### PR DESCRIPTION
## Summary
- integrate FAL client and endpoints for submitting and tracking jobs
- add APScheduler polling and Prometheus metrics
- enforce admin guard and expose videos via source URLs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c75c617bf48327b1d4a3bcad4a805b