### PR TITLE
Show Supabase user info on dashboard

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -149,6 +149,7 @@ def login():
                         row = cur.fetchone()
                         if row:
                             session["role"] = row[0]
+                            session["gpu_minutes_quota"] = row[1]
                             profile_payload.update(
                                 {"role": row[0], "gpu_minutes_quota": row[1]}
                             )
@@ -183,6 +184,7 @@ def login():
                     row = cur.fetchone()
                     if row:
                         session["role"] = row[0]
+                        session["gpu_minutes_quota"] = row[1]
                         profile_payload.update(
                             {"role": row[0], "gpu_minutes_quota": row[1]}
                         )
@@ -267,7 +269,9 @@ def dashboard():
     return render_template(
         "dashboard.html",
         user_id=session["user_id"],
+        email=session.get("email"),
         role=session.get("role", "user"),
+        gpu_minutes_quota=session.get("gpu_minutes_quota"),
     )
 
 

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -3,6 +3,14 @@
 {% block content %}
 <div class="max-w-3xl mx-auto space-y-8">
   <h1 class="text-3xl font-semibold text-center">Dashboard</h1>
+  <div class="space-y-1 text-sm">
+    <p><strong>Email:</strong> {{ email }}</p>
+    <p><strong>User ID:</strong> {{ user_id }}</p>
+    <p><strong>Role:</strong> {{ role }}</p>
+    {% if gpu_minutes_quota is not none %}
+    <p><strong>GPU minutes quota:</strong> {{ gpu_minutes_quota }}</p>
+    {% endif %}
+  </div>
   {% if session.get('role') == 'admin' %}
   <div class="text-right">
     <a href="/admin" class="px-4 py-2 rounded bg-indigo-500 hover:bg-indigo-400 text-slate-900 font-semibold">Admin Dashboard</a>


### PR DESCRIPTION
## Summary
- Persist user role and GPU minutes from Supabase in session during login
- Display email, user ID, role, and GPU minutes quota on dashboard

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7ffa8f1a0832789783f66cd1ac1fb