### PR TITLE
Display Supabase connection status

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -68,15 +68,26 @@ except Exception:
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_KEY = os.getenv("SUPABASE_SERVICE_KEY")  # ⚠️ utilise la service_role key
 supabase: Client | None = None
+supabase_connected = False
 if SUPABASE_URL and SUPABASE_KEY:
     try:
         supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+        # Vérifie la connexion en faisant une requête simple
+        supabase.table("profiles").select("id").limit(1).execute()
+        supabase_connected = True
     except Exception:
         supabase = None
+        supabase_connected = False
 
 
 REQS = Counter("flask_http_requests_total", "count", ["method", "endpoint", "status"])
 LAT = Histogram("flask_http_request_seconds", "latency", ["endpoint"])
+
+
+@app.context_processor
+def inject_supabase_status():
+    """Injecte l'état de connexion Supabase dans les templates"""
+    return {"supabase_connected": supabase_connected}
 
 
 def require_admin(f):

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -4,6 +4,11 @@
 <section class="text-center py-24">
   <h1 class="text-5xl font-bold mb-6 tracking-tight">Veo 3 Fast [Image to Video]</h1>
   <p class="mb-8 text-lg text-slate-300">Generate videos from your image prompts using Veo 3 fast.</p>
+  {% if supabase_connected %}
+  <p class="mb-4 text-sm text-green-400">Connexion à Supabase réussie</p>
+  {% else %}
+  <p class="mb-4 text-sm text-red-400">Échec de connexion à Supabase</p>
+  {% endif %}
   <div class="space-x-4">
     {% if session.get('user_id') %}
     <a href="/generate" class="px-6 py-3 rounded-md bg-teal-500 hover:bg-teal-400 text-slate-900 font-semibold">Essayer</a>


### PR DESCRIPTION
## Summary
- Verify Supabase connectivity during app startup and track the status
- Expose Supabase connection state to templates
- Show connection result on the homepage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c8021aff148327827fd935e3f3caeb