### PR TITLE
feat: add Wikipedia scraping and summarization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ fal-client==0.7.0
 APScheduler==3.10.4
 prometheus_client==0.19.0
 requests==2.31.0
+beautifulsoup4==4.12.3

--- a/src/templates/generate.html
+++ b/src/templates/generate.html
@@ -7,8 +7,10 @@
     <input id="prompt" class="w-full px-4 py-2 rounded bg-slate-900 border border-slate-700 focus:outline-none focus:ring-2 focus:ring-teal-500" type="text" placeholder="Enter prompt" required />
     <input id="image-url" class="w-full px-4 py-2 rounded bg-slate-900 border border-slate-700 focus:outline-none focus:ring-2 focus:ring-teal-500" type="text" placeholder="Image URL" required />
     <button class="w-full py-2 rounded bg-teal-500 hover:bg-teal-400 text-slate-900 font-semibold" type="submit">Generate</button>
+    <button id="wiki-btn" class="w-full py-2 rounded bg-indigo-500 hover:bg-indigo-400 text-slate-900 font-semibold" type="button">Wiki Search</button>
   </form>
   <pre id="result" class="bg-slate-900 p-4 rounded text-sm"></pre>
+  <pre id="wiki-result" class="bg-slate-900 p-4 rounded text-sm"></pre>
 </div>
 <script>
 const USER_ID = {{ user_id | tojson }};
@@ -27,6 +29,17 @@ document.getElementById('gen-form').addEventListener('submit', async (e) => {
   });
   const data = await res.json();
   document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+});
+
+document.getElementById('wiki-btn').addEventListener('click', async () => {
+  const prompt = document.getElementById('prompt').value;
+  const res = await fetch('/wiki_summary', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({query: prompt})
+  });
+  const data = await res.json();
+  document.getElementById('wiki-result').textContent = JSON.stringify(data, null, 2);
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add backend helpers to extract keywords with Ollama, fetch and clean Wikipedia pages, and summarize content
- expose `/wiki_summary` endpoint and frontend button to trigger scraping and display debug results
- include beautifulsoup4 dependency and tests for the new endpoint

## Testing
- `pytest bloc4_final_project/src/tests/test_app.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c8093a68a08327872965be1e8b455e