### PR TITLE
Add refresh and navigation buttons to front end

### DIFF
--- a/src/templates/admin_dashboard.html
+++ b/src/templates/admin_dashboard.html
@@ -3,6 +3,9 @@
 {% block content %}
 <div class="space-y-8">
   <h1 class="text-3xl font-semibold text-center">Admin Dashboard</h1>
+  <div class="text-right">
+    <button id="refresh-admin" class="px-4 py-2 rounded bg-teal-500 hover:bg-teal-400 text-slate-900 font-semibold">Refresh Data</button>
+  </div>
   <section>
     <h2 class="text-xl font-semibold mb-2">Jobs</h2>
     <table class="min-w-full text-sm" id="admin-jobs-table">
@@ -58,7 +61,8 @@ async function loadAdmin() {
   jobs.forEach(j => {
     let videoLinks = '';
     if (j.video_url) {
-      videoLinks = `<a href="${j.video_url}" target="_blank" class="text-teal-400">View</a>`;
+      videoLinks = `<a href="${j.video_url}" target="_blank" class="text-teal-400">View</a>` +
+                   ` <a href="${j.video_url}" download class="text-teal-400 ml-2">Download</a>`;
     }
     const tr = document.createElement('tr');
     tr.innerHTML = `<td class="px-2 py-1">${j.id}</td>`+
@@ -117,5 +121,7 @@ async function loadAdmin() {
 }
 
 document.addEventListener('DOMContentLoaded', loadAdmin);
+
+document.getElementById('refresh-admin').addEventListener('click', loadAdmin);
 </script>
 {% endblock %}

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -21,6 +21,9 @@
     <input id="image-url" class="w-full px-4 py-2 rounded bg-slate-900 border border-slate-700 focus:outline-none focus:ring-2 focus:ring-teal-500" type="text" placeholder="Image URL" required />
     <button class="w-full py-2 rounded bg-teal-500 hover:bg-teal-400 text-slate-900 font-semibold" type="submit">Submit</button>
   </form>
+  <div class="text-right">
+    <button id="refresh-jobs" class="px-4 py-2 rounded bg-teal-500 hover:bg-teal-400 text-slate-900 font-semibold">Refresh Jobs</button>
+  </div>
   <table class="min-w-full text-sm" id="jobs-table">
     <thead>
       <tr class="text-left">
@@ -68,6 +71,8 @@ document.getElementById('job-form').addEventListener('submit', async (e) => {
   });
   loadJobs();
 });
+
+document.getElementById('refresh-jobs').addEventListener('click', loadJobs);
 
 document.addEventListener('DOMContentLoaded', loadJobs);
 </script>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -11,6 +11,7 @@
   {% endif %}
   <div class="space-x-4">
     {% if session.get('user_id') %}
+    <a href="/dashboard" class="px-6 py-3 rounded-md bg-blue-500 hover:bg-blue-400 text-slate-900 font-semibold">Dashboard</a>
     <a href="/generate" class="px-6 py-3 rounded-md bg-teal-500 hover:bg-teal-400 text-slate-900 font-semibold">Essayer</a>
     {% if session.get('role') == 'admin' %}
     <a href="/admin" class="px-6 py-3 rounded-md bg-indigo-500 hover:bg-indigo-400 text-slate-900 font-semibold">Admin</a>


### PR DESCRIPTION
## Summary
- add dashboard access button on home page
- add refresh controls to dashboard and admin dashboards
- allow admins to download generated videos

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c81cfc947c8327a9ffed219acb99f6