### PR TITLE
Improve Wikipedia scraping reliability

### DIFF
--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -109,6 +109,22 @@ function renderScrapeResults(data, jobId) {
     });
     debugOutput.appendChild(list);
   }
+
+  if (Array.isArray(data.errors) && data.errors.length) {
+    const errorHeading = document.createElement('p');
+    errorHeading.className = 'text-red-400 font-semibold mt-3';
+    errorHeading.textContent = 'Errors';
+    debugOutput.appendChild(errorHeading);
+
+    const errorsList = document.createElement('ul');
+    errorsList.className = 'list-disc list-inside mt-1 space-y-1 text-red-300';
+    data.errors.forEach(message => {
+      const li = document.createElement('li');
+      li.textContent = message;
+      errorsList.appendChild(li);
+    });
+    debugOutput.appendChild(errorsList);
+  }
 }
 
 function normalizeError(err) {


### PR DESCRIPTION
## Summary
- send a dedicated User-Agent with Wikipedia API and page requests and raise on HTTP errors
- propagate search/scrape failures back through /wiki_summary and display them on the dashboard
- extend the Flask test suite to cover the new Wikipedia logic and error reporting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8fd203c008327ab680049cac8f675