### PR TITLE
Use Supabase REST client for jobs

### DIFF
--- a/src/tests/_supabase_dummy.py
+++ b/src/tests/_supabase_dummy.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Tuple
+
+
+@dataclass
+class _Record:
+    op: str
+    table: str
+    payload: Dict[str, Any]
+    filters: List[Tuple[str, Any]] = field(default_factory=list)
+
+
+class DummySupabase:
+    """Petit double Supabase pour les tests unitaires."""
+
+    def __init__(self) -> None:
+        self.records: list[_Record] = []
+        self.select_responses: dict[str, list[list[dict[str, Any]]]] = {}
+        self.next_ids: dict[str, int] = {"jobs": 1, "files": 1, "videos": 1}
+        self.auth = type("Auth", (), {})()
+
+    def queue_select(self, table: str, rows: list[dict[str, Any]]) -> None:
+        self.select_responses.setdefault(table, []).append(rows)
+
+    def table(self, name: str):
+        return _DummyTable(self, name)
+
+
+class _DummyTable:
+    def __init__(self, supabase: DummySupabase, name: str) -> None:
+        self.supabase = supabase
+        self.name = name
+        self._filters: list[tuple[str, Any]] = []
+
+    # Chaîne de méthodes utilisée par supabase-py
+    def select(self, *args: Any, **kwargs: Any):  # pragma: no cover - arguments ignorés
+        return self
+
+    def insert(self, payload: dict[str, Any]):
+        return _DummyInsert(self.supabase, self.name, payload)
+
+    def update(self, payload: dict[str, Any]):
+        return _DummyUpdate(self.supabase, self.name, payload)
+
+    def eq(self, column: str, value: Any):
+        self._filters.append(("eq", column, value))
+        return self
+
+    def in_(self, column: str, values: list[Any]):
+        self._filters.append(("in", column, tuple(values)))
+        return self
+
+    def order(self, column: str, desc: bool = False):  # pragma: no cover
+        self._filters.append(("order", column, desc))
+        return self
+
+    def limit(self, count: int):  # pragma: no cover - stocké pour debug
+        self._filters.append(("limit", count))
+        return self
+
+    @property
+    def not_(self):
+        return _DummyNot(self)
+
+    def execute(self):
+        rows = self.supabase.select_responses.get(self.name, [])
+        data = rows.pop(0) if rows else []
+        return type("Resp", (), {"data": data})()
+
+
+class _DummyInsert:
+    def __init__(self, supabase: DummySupabase, table: str, payload: dict[str, Any]) -> None:
+        self.supabase = supabase
+        self.table = table
+        self.payload = payload
+
+    def execute(self):
+        record = dict(self.payload)
+        if self.table in self.supabase.next_ids and "id" not in record:
+            next_id = self.supabase.next_ids[self.table]
+            record["id"] = next_id
+            self.supabase.next_ids[self.table] = next_id + 1
+        self.supabase.records.append(_Record("insert", self.table, record))
+        return type("Resp", (), {"data": [record]})()
+
+
+class _DummyUpdate:
+    def __init__(self, supabase: DummySupabase, table: str, payload: dict[str, Any]) -> None:
+        self.supabase = supabase
+        self.table = table
+        self.payload = payload
+        self.filters: list[tuple[str, Any]] = []
+
+    def eq(self, column: str, value: Any):
+        self.filters.append(("eq", column, value))
+        return self
+
+    def execute(self):
+        self.supabase.records.append(
+            _Record("update", self.table, self.payload, list(self.filters))
+        )
+        return type("Resp", (), {"data": []})()
+
+
+class _DummyNot:
+    def __init__(self, table: _DummyTable) -> None:
+        self.table = table
+
+    def is_(self, column: str, value: Any):  # pragma: no cover - simple enchainement
+        self.table._filters.append(("not.is", column, value))
+        return self.table

--- a/src/tests/test_fal.py
+++ b/src/tests/test_fal.py
@@ -2,110 +2,52 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.dirname(__file__))
 
 import app as app_module
 from app import app, _sync_fal_jobs  # type: ignore
+from _supabase_dummy import DummySupabase
 
 
 def test_submit_job_fal(monkeypatch):
     client = app.test_client()
 
-    class DummyCursor:
-        def __init__(self, history):
-            self.history = history
-            self.fetchone_result = None
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            pass
-
-        def execute(self, sql, params=None):
-            self.history.append((sql, params))
-            if "RETURNING id" in sql:
-                self.fetchone_result = (1,)
-            else:
-                self.fetchone_result = None
-
-        def fetchone(self):
-            return self.fetchone_result
-
-    class DummyConn:
-        def __init__(self):
-            self.history = []
-
-        def cursor(self):
-            return DummyCursor(self.history)
-
-        def commit(self):
-            pass
-
-        def rollback(self):
-            pass
-
-    dummy_conn = DummyConn()
-    monkeypatch.setattr(app_module, "conn", dummy_conn)
+    dummy_supabase = DummySupabase()
+    monkeypatch.setattr(app_module, "supabase", dummy_supabase)
     monkeypatch.setattr(app_module, "submit_text2video", lambda *a, **k: "req_123")
 
     resp = client.post("/submit_job_fal", json={"user_id": 1, "prompt": "hello"})
     assert resp.status_code == 202
     data = resp.get_json()
     assert data["external_job_id"] == "req_123"
-    assert any("INSERT INTO jobs" in sql for sql, _ in dummy_conn.history)
-    assert any("UPDATE jobs SET external_job_id" in sql for sql, _ in dummy_conn.history)
+    inserts = [rec for rec in dummy_supabase.records if rec.op == "insert" and rec.table == "jobs"]
+    assert inserts and inserts[0].payload["prompt"] == "hello"
+    updates = [rec for rec in dummy_supabase.records if rec.op == "update" and rec.table == "jobs"]
+    assert any(rec.payload.get("external_job_id") == "req_123" for rec in updates)
 
 
 def test_scheduler_sync_success(monkeypatch):
-    class DummyCursor:
-        def __init__(self, history):
-            self.history = history
-            self.fetchall_result = []
-            self.fetchone_result = None
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            pass
-
-        def execute(self, sql, params=None):
-            self.history.append((sql, params))
-            if "SELECT id, external_job_id" in sql:
-                self.fetchall_result = [(1, "req_123", "model")]
-            elif "SELECT user_id FROM jobs" in sql:
-                self.fetchone_result = (42,)
-            else:
-                self.fetchall_result = []
-                self.fetchone_result = None
-
-        def fetchall(self):
-            return self.fetchall_result
-
-        def fetchone(self):
-            return self.fetchone_result
-
-    class DummyConn:
-        def __init__(self):
-            self.history = []
-
-        def cursor(self):
-            return DummyCursor(self.history)
-
-        def commit(self):
-            pass
-
-        def rollback(self):
-            pass
-
-    dummy_conn = DummyConn()
-    monkeypatch.setattr(app_module, "conn", dummy_conn)
+    dummy_supabase = DummySupabase()
+    dummy_supabase.queue_select(
+        "jobs",
+        [
+            {
+                "id": 1,
+                "external_job_id": "req_123",
+                "params": {"model_id": "model"},
+                "user_id": 42,
+            }
+        ],
+    )
+    monkeypatch.setattr(app_module, "supabase", dummy_supabase)
     monkeypatch.setattr(app_module, "get_status", lambda *a, **k: {"status": "SUCCESS"})
     monkeypatch.setattr(app_module, "get_result", lambda *a, **k: {"video": {"url": "http://v"}})
 
     _sync_fal_jobs()
-    assert any("INSERT INTO videos" in sql for sql, _ in dummy_conn.history)
-    assert any("status='succeeded'" in sql for sql, _ in dummy_conn.history)
+    video_inserts = [rec for rec in dummy_supabase.records if rec.op == "insert" and rec.table == "videos"]
+    assert video_inserts and video_inserts[0].payload["job_id"] == 1
+    job_updates = [rec for rec in dummy_supabase.records if rec.op == "update" and rec.table == "jobs"]
+    assert any(rec.payload.get("status") == "succeeded" for rec in job_updates)
 
 
 def test_admin_guard():


### PR DESCRIPTION
## Summary
- allow configuring Supabase client from service, generic or anon keys and generate real timestamps via REST updates
- replace the Celery worker's direct PostgreSQL access with Supabase REST operations for job polling and video persistence
- add a reusable Supabase test double and update tests to cover the REST-based flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c91c68dcf8832798f8b506fd270c9e