### PR TITLE
Add fal.ai webhook verification and UI status updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ requests==2.31.0
 beautifulsoup4==4.12.3
 pyspark==3.5.1
 redis==5.0.1
+PyNaCl==1.5.0

--- a/src/fal_client.py
+++ b/src/fal_client.py
@@ -4,12 +4,15 @@ from typing import Any
 
 import requests
 
-FAL_BASE = "https://api.fal.ai"
+FAL_BASE = os.getenv("FAL_API_BASE", "https://api.fal.ai")
+FAL_QUEUE_BASE = os.getenv("FAL_QUEUE_BASE", "https://queue.fal.run")
 FAL_KEY = os.getenv("FAL_KEY")
 
 
 def _headers(json: bool = True):
-    headers = {"Authorization": f"Bearer {FAL_KEY}"}
+    headers = {}
+    if FAL_KEY:
+        headers["Authorization"] = f"Key {FAL_KEY}"
     if json:
         headers["Content-Type"] = "application/json"
     return headers
@@ -35,11 +38,15 @@ def submit_text2video(
     webhook_url: str | None = None,
 ) -> str:
     payload: dict[str, object] = {"input": _normalize_input(input_data)}
+    params = None
     if webhook_url:
         payload["webhookUrl"] = webhook_url
+        params = {"fal_webhook": webhook_url}
+    endpoint = f"{FAL_QUEUE_BASE.rstrip('/')}/{model_id.lstrip('/')}"
     r = requests.post(
-        f"{FAL_BASE}/models/{model_id}/api/queue/submit",
+        endpoint,
         headers=_headers(),
+        params=params,
         json=payload,
         timeout=30,
     )

--- a/src/fal_webhook.py
+++ b/src/fal_webhook.py
@@ -1,0 +1,131 @@
+"""Utilities for validating fal.ai webhook signatures."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import time
+from typing import Callable, Iterable, Mapping, Sequence
+
+import requests
+from nacl.exceptions import BadSignatureError
+from nacl.signing import VerifyKey
+
+
+__all__ = [
+    "FalWebhookVerificationError",
+    "fetch_jwks",
+    "verify_fal_webhook",
+]
+
+
+JWKS_URL = os.getenv(
+    "FAL_JWKS_URL",
+    "https://rest.alpha.fal.ai/.well-known/jwks.json",
+)
+
+_MAX_CACHE_SECONDS = 24 * 60 * 60
+try:
+    _configured_cache = int(os.getenv("FAL_JWKS_CACHE_SECONDS", "3600"))
+except ValueError:  # pragma: no cover - invalid env configuration
+    _configured_cache = 3600
+
+JWKS_CACHE_SECONDS = min(max(_configured_cache, 60), _MAX_CACHE_SECONDS)
+
+_jwks_cache: list[dict[str, object]] | None = None
+_jwks_cache_expiry: float = 0.0
+
+
+class FalWebhookVerificationError(RuntimeError):
+    """Raised when a fal.ai webhook signature cannot be validated."""
+
+
+def _decode_base64url(data: str) -> bytes:
+    padding = "=" * ((4 - len(data) % 4) % 4)
+    return base64.urlsafe_b64decode((data + padding).encode("ascii"))
+
+
+def fetch_jwks(force_refresh: bool = False) -> list[dict[str, object]]:
+    """Fetch the JSON Web Key Set used to verify webhook signatures."""
+
+    global _jwks_cache, _jwks_cache_expiry
+    now = time.time()
+    if (
+        force_refresh
+        or _jwks_cache is None
+        or now >= _jwks_cache_expiry
+    ):
+        response = requests.get(JWKS_URL, timeout=10)
+        response.raise_for_status()
+        payload = response.json()
+        keys = payload.get("keys")
+        if not isinstance(keys, list):
+            keys = []
+        _jwks_cache = keys  # type: ignore[assignment]
+        _jwks_cache_expiry = now + JWKS_CACHE_SECONDS
+    return _jwks_cache or []
+
+
+def _required_header(headers: Mapping[str, str], name: str) -> str:
+    value = headers.get(name)
+    if value is None:
+        raise FalWebhookVerificationError(f"missing header: {name}")
+    return value
+
+
+def verify_fal_webhook(
+    headers: Mapping[str, str],
+    body: bytes,
+    *,
+    fetch_keys: Callable[[], Sequence[Mapping[str, object]]] = fetch_jwks,
+    now: float | None = None,
+) -> None:
+    """Validate the webhook signature.
+
+    Raises ``FalWebhookVerificationError`` when the request cannot be
+    authenticated.
+    """
+
+    request_id = _required_header(headers, "X-Fal-Webhook-Request-Id")
+    user_id = _required_header(headers, "X-Fal-Webhook-User-Id")
+    timestamp_raw = _required_header(headers, "X-Fal-Webhook-Timestamp")
+    signature_hex = _required_header(headers, "X-Fal-Webhook-Signature")
+
+    try:
+        timestamp_int = int(timestamp_raw)
+    except ValueError as exc:
+        raise FalWebhookVerificationError("invalid timestamp") from exc
+
+    current_time = int(now if now is not None else time.time())
+    if abs(current_time - timestamp_int) > 300:
+        raise FalWebhookVerificationError("timestamp outside tolerance")
+
+    digest = hashlib.sha256(body).hexdigest()
+    message = "\n".join([request_id, user_id, timestamp_raw, digest]).encode("utf-8")
+
+    try:
+        signature = bytes.fromhex(signature_hex)
+    except ValueError as exc:
+        raise FalWebhookVerificationError("invalid signature format") from exc
+
+    try:
+        keys: Iterable[Mapping[str, object]] = fetch_keys()
+    except Exception as exc:  # pragma: no cover - network failure propagated
+        raise FalWebhookVerificationError("unable to fetch JWKS") from exc
+    verified = False
+    for key_info in keys:
+        key_data = key_info.get("x")
+        if not isinstance(key_data, str):
+            continue
+        try:
+            public_key = _decode_base64url(key_data)
+            verify_key = VerifyKey(public_key)
+            verify_key.verify(message, signature)
+            verified = True
+            break
+        except (BadSignatureError, ValueError, TypeError):
+            continue
+
+    if not verified:
+        raise FalWebhookVerificationError("signature verification failed")

--- a/src/templates/generate.html
+++ b/src/templates/generate.html
@@ -3,32 +3,135 @@
 {% block content %}
 <div class="max-w-2xl mx-auto space-y-6">
   <h1 class="text-3xl font-semibold text-center">Generate Video</h1>
+  <p class="text-sm text-slate-400 text-center">
+    Submit a prompt to schedule a fal.ai video generation request. The job is queued on
+    fal.ai and this page monitors the status using your Supabase records and webhooks.
+  </p>
   <form id="gen-form" class="space-y-4">
     <input id="prompt" class="w-full px-4 py-2 rounded bg-slate-900 border border-slate-700 focus:outline-none focus:ring-2 focus:ring-teal-500" type="text" placeholder="Enter prompt" required />
     <input id="image-url" class="w-full px-4 py-2 rounded bg-slate-900 border border-slate-700 focus:outline-none focus:ring-2 focus:ring-teal-500" type="text" placeholder="Image URL" required />
     <button class="w-full py-2 rounded bg-teal-500 hover:bg-teal-400 text-slate-900 font-semibold" type="submit">Generate</button>
     <button id="wiki-btn" class="w-full py-2 rounded bg-indigo-500 hover:bg-indigo-400 text-slate-900 font-semibold" type="button">Wiki Search</button>
   </form>
+  <section class="p-4 rounded-lg border border-slate-700 bg-slate-900/50 space-y-2">
+    <h2 class="text-sm font-semibold text-slate-200">fal.ai request status</h2>
+    <p id="request-state" class="text-xs text-slate-400">No request submitted yet.</p>
+    <dl id="request-meta" class="grid grid-cols-1 gap-1 text-xs text-slate-400 hidden">
+      <div class="flex items-center justify-between gap-2">
+        <dt class="font-medium text-slate-300">Request ID</dt>
+        <dd id="request-id" class="text-right break-all"></dd>
+      </div>
+      <div class="flex items-center justify-between gap-2">
+        <dt class="font-medium text-slate-300">Webhook URL</dt>
+        <dd id="webhook-url" class="text-right break-all"></dd>
+      </div>
+    </dl>
+  </section>
   <pre id="result" class="bg-slate-900 p-4 rounded text-sm"></pre>
   <pre id="wiki-result" class="bg-slate-900 p-4 rounded text-sm"></pre>
 </div>
 <script>
 const USER_ID = {{ user_id | tojson }};
+const requestState = document.getElementById('request-state');
+const requestMeta = document.getElementById('request-meta');
+const requestIdEl = document.getElementById('request-id');
+const webhookEl = document.getElementById('webhook-url');
+let pollTimeout = null;
+
+function setState(message, tone = 'info') {
+  if (!requestState) return;
+  const classes = {
+    info: 'text-xs text-slate-300',
+    active: 'text-xs text-amber-300',
+    success: 'text-xs text-emerald-300',
+    error: 'text-xs text-red-300'
+  };
+  requestState.className = classes[tone] || classes.info;
+  requestState.textContent = message;
+}
+
+function updateRequestMeta(data) {
+  if (!requestMeta) return;
+  if (!data) {
+    requestMeta.classList.add('hidden');
+    requestIdEl.textContent = '';
+    webhookEl.textContent = '';
+    return;
+  }
+  requestMeta.classList.remove('hidden');
+  requestIdEl.textContent = data.external_job_id || '—';
+  webhookEl.textContent = data.webhook_url || '—';
+}
+
+async function pollJobStatus(jobId) {
+  if (pollTimeout) {
+    clearTimeout(pollTimeout);
+    pollTimeout = null;
+  }
+  if (!jobId) return;
+
+  const poll = async () => {
+    try {
+      const resp = await fetch(`/list_jobs/${USER_ID}`);
+      if (!resp.ok) {
+        throw new Error(`HTTP ${resp.status}`);
+      }
+      const jobs = await resp.json();
+      const job = Array.isArray(jobs) ? jobs.find((item) => item.id === jobId) : null;
+      if (!job) {
+        setState('Waiting for job to appear in Supabase…', 'active');
+      } else if (job.status === 'succeeded') {
+        setState('✅ Video generated successfully! Check your library for the file.', 'success');
+        return;
+      } else if (job.status === 'failed') {
+        const reason = job.error ? ` Reason: ${job.error}` : '';
+        setState(`The request failed.${reason}`, 'error');
+        return;
+      } else {
+        const statusLabel = job.status === 'running' ? 'Processing' : 'Queued';
+        setState(`${statusLabel}… waiting for fal.ai webhook.`, 'active');
+      }
+    } catch (err) {
+      setState(`Unable to fetch job status: ${err.message}`, 'error');
+      return;
+    }
+    pollTimeout = setTimeout(poll, 4000);
+  };
+  poll();
+}
+
 document.getElementById('gen-form').addEventListener('submit', async (e) => {
   e.preventDefault();
   const prompt = document.getElementById('prompt').value;
   const imageUrl = document.getElementById('image-url').value;
-  const res = await fetch('/submit_job', {
+  setState('Submitting job to fal.ai…', 'active');
+  const res = await fetch('/submit_job_fal', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({
       user_id: USER_ID,
       prompt,
-      params: { image_url: imageUrl }
+      text_input: prompt,
+      image_url: imageUrl
     })
   });
-  const data = await res.json();
+  let data;
+  try {
+    data = await res.json();
+  } catch (err) {
+    setState('Failed to parse response from the server.', 'error');
+    return;
+  }
   document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+  if (!res.ok) {
+    const errorMsg = data && data.error ? data.error : 'The fal.ai submission failed.';
+    setState(errorMsg, 'error');
+    updateRequestMeta(null);
+    return;
+  }
+  updateRequestMeta(data);
+  setState('Job queued at fal.ai. Waiting for status updates…', 'active');
+  pollJobStatus(data.job_id);
 });
 
 document.getElementById('wiki-btn').addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- add a `fal_webhook` helper module to validate webhook signatures using fal.ai JWKS keys
- update the Flask API to send webhook URLs to fal.ai, process new payload formats, and surface request status on the generate page
- extend tests to cover webhook verification and queue submissions while updating the client to hit the queue domain

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c933ba64f08327a87ba04f30f0f234