### PR TITLE
Refine Ollama script prompt and surface fal.ai job stages

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -190,14 +190,22 @@ def scrape_and_clean(url: str) -> tuple[str, str | None]:
         return "", f"Failed to parse HTML: {exc}"
 
 
-def summarize_text(text: str) -> str:
-    """Résume un texte en utilisant Ollama ou un fallback simple."""
+def summarize_text(text: str, topic_hint: str | None = None) -> str:
+    """Génère un script vidéo pédagogique à partir d'un texte et d'un sujet donné."""
+    learner_request = topic_hint.strip() if isinstance(topic_hint, str) else ""
     prompt = (
-        "You are a seasoned course creator preparing a short script for a talking-head "
-        "educational video. Using the following reference material, craft a motivating "
-        "narration that sounds like it will be spoken directly to learners. Keep the tone "
-        "encouraging, mention the central idea once, and avoid bullet points.\n"
-        f"{text}\nCourse video script:"
+        "You are an expert course designer preparing the narration for a short explainer "
+        "video lesson. First, identify the main topic the learner wants to explore based "
+        "on their request below. Then, craft a motivating mini-course script that "
+        "contains an inviting introduction, two or three concise teaching moments, and a "
+        "closing encouragement. Speak directly to the learner, keep paragraphs short, "
+        "avoid bullet points, and reuse the reference notes only when they support the "
+        "explanation. Whenever possible, reply in the same language as the learner's "
+        "request.\n"
+        f"Learner request: {learner_request or 'Not provided'}\n"
+        "Reference notes:\n"
+        f"{text}\n"
+        "Explainer video script:"
     )
     summary = ollama_generate(prompt)
     if summary:
@@ -570,7 +578,7 @@ def wiki_summary():
                 )
 
     combined_text = " ".join(texts)
-    summary = summarize_text(combined_text) if combined_text else ""
+    summary = summarize_text(combined_text, query) if combined_text else ""
 
     payload: dict[str, object] = {
         "keywords": keywords,

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -48,6 +48,8 @@
       <tr class="text-left">
         <th class="px-2 py-1">ID</th>
         <th class="px-2 py-1">Prompt</th>
+        <th class="px-2 py-1">Provider</th>
+        <th class="px-2 py-1">Request ID</th>
         <th class="px-2 py-1">Status</th>
         <th class="px-2 py-1">Submitted</th>
         <th class="px-2 py-1">Video</th>
@@ -62,9 +64,11 @@ const USER_ID = {{ user_id | tojson }};
 const debugOutput = document.getElementById('scrape-debug');
 const statusOutput = document.getElementById('scrape-status');
 const STATUS_STEPS = [
-  { id: 'queued', label: 'Queued' },
-  { id: 'summarizing', label: 'Summarizing' },
-  { id: 'generating', label: 'Generating' }
+  { id: 'queued', label: 'Job queued' },
+  { id: 'summary', label: 'Ollama summary' },
+  { id: 'fal_request', label: 'fal.ai submission' },
+  { id: 'webhook', label: 'Webhook update' },
+  { id: 'generation', label: 'Video generation' }
 ];
 const statusElements = new Map();
 let pollSequence = 0;
@@ -240,19 +244,27 @@ async function loadJobs() {
       videoLinks = `<a href="${job.video_url}" target="_blank" class="text-teal-400">View</a>`+
                    ` <a href="${job.video_url}" download class="text-teal-400 ml-2">Download</a>`;
     }
+    const provider = job.provider || '—';
+    const requestId = job.external_job_id || '—';
+    const promptText = job.prompt || '';
+    const submittedAt = job.submitted_at || '—';
+    const statusText = job.status || '—';
     tr.innerHTML = `<td class="px-2 py-1">${job.id}</td>`+
-                   `<td class="px-2 py-1">${job.prompt}</td>`+
-                   `<td class="px-2 py-1">${job.status}</td>`+
-                   `<td class="px-2 py-1">${job.submitted_at}</td>`+
+                   `<td class="px-2 py-1">${promptText}</td>`+
+                   `<td class="px-2 py-1">${provider}</td>`+
+                   `<td class="px-2 py-1">${requestId}</td>`+
+                   `<td class="px-2 py-1">${statusText}</td>`+
+                   `<td class="px-2 py-1">${submittedAt}</td>`+
                    `<td class="px-2 py-1">${videoLinks}</td>`;
     body.appendChild(tr);
   });
 }
 
 async function pollJobUntilComplete(jobId, options = {}) {
-  const { interval = 5000, maxAttempts = 15 } = options;
+  const { interval = 5000, maxAttempts = 15, requestId = null } = options;
   const sequence = ++pollSequence;
   let lastStatus = null;
+  let knownRequestId = requestId;
 
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     if (sequence !== pollSequence) {
@@ -296,6 +308,8 @@ async function pollJobUntilComplete(jobId, options = {}) {
 
     const job = jobs.find(j => j.id === jobId);
     if (!job) {
+      setStatus('webhook', 'active', 'Waiting for Supabase record');
+      updateGenerationStatus(`Waiting for job #${jobId} to appear in Supabase…`, 'active');
       continue;
     }
 
@@ -304,32 +318,46 @@ async function pollJobUntilComplete(jobId, options = {}) {
       loadJobs();
     }
 
+    if (job.external_job_id && job.external_job_id !== knownRequestId) {
+      knownRequestId = job.external_job_id;
+      setStatus('fal_request', 'done', `Request ${knownRequestId} accepted`);
+    }
+
     const normalizedStatus = typeof job.status === 'string' ? job.status.toLowerCase() : '';
 
     if (normalizedStatus === 'succeeded') {
       if (sequence !== pollSequence) return;
-      setStatus('generating', 'done', 'Video ready');
-      updateGenerationStatus(`Video generated successfully for job #${jobId}.`, 'success');
+      setStatus('webhook', 'done', 'fal.ai delivered the result');
+      setStatus('generation', 'done', 'Video ready');
+      const reqDisplay = knownRequestId ? ` (request ${knownRequestId})` : '';
+      updateGenerationStatus(`Video generated successfully for job #${jobId}${reqDisplay}.`, 'success');
       loadJobs();
       return;
     }
 
     if (normalizedStatus === 'failed') {
       if (sequence !== pollSequence) return;
-      setStatus('generating', 'error', 'Generation failed');
-      updateGenerationStatus(`Video generation failed for job #${jobId}.`, 'error');
+      setStatus('webhook', 'error', 'fal.ai reported a failure');
+      setStatus('generation', 'error', 'Generation failed');
+      const reqDisplay = knownRequestId ? ` (request ${knownRequestId})` : '';
+      updateGenerationStatus(`Video generation failed for job #${jobId}${reqDisplay}.`, 'error');
       loadJobs();
       return;
     }
 
     if (normalizedStatus === 'running') {
-      setStatus('generating', 'active', 'Video generation in progress');
-      updateGenerationStatus('Video generation in progress...', 'active');
+      setStatus('webhook', 'active', 'fal.ai processing');
+      setStatus('generation', 'active', 'Video generation in progress');
+      const reqDisplay = knownRequestId ? ` (request ${knownRequestId})` : '';
+      updateGenerationStatus(`Video generation in progress${reqDisplay}…`, 'active');
     } else if (normalizedStatus === 'queued') {
-      setStatus('generating', 'active', 'Queued for generation');
-      updateGenerationStatus('Job queued for generation...', 'active');
+      setStatus('webhook', 'active', 'Waiting for fal.ai to start');
+      setStatus('generation', 'pending', 'Waiting to start');
+      const reqDisplay = knownRequestId ? ` (request ${knownRequestId})` : '';
+      updateGenerationStatus(`Job queued for generation${reqDisplay}…`, 'active');
     } else {
-      setStatus('generating', 'active', job.status || 'In progress');
+      setStatus('webhook', 'active', job.status || 'In progress');
+      setStatus('generation', 'active', 'Processing update received');
       updateGenerationStatus(`Current job status: ${job.status}`, 'active');
     }
   }
@@ -337,7 +365,8 @@ async function pollJobUntilComplete(jobId, options = {}) {
   if (sequence !== pollSequence) {
     return;
   }
-  setStatus('generating', 'error', 'Timed out');
+  setStatus('webhook', 'error', 'Timed out waiting for webhook');
+  setStatus('generation', 'error', 'Timed out');
   updateGenerationStatus('Timed out waiting for video generation to finish.', 'error');
 }
 
@@ -347,27 +376,58 @@ document.getElementById('job-form').addEventListener('submit', async (e) => {
   const imageUrl = document.getElementById('image-url').value;
   resetStatuses();
   setStatus('queued', 'active', 'Submitting job');
-  updateDebugMessage('Submitting job...');
+  setStatus('fal_request', 'active', 'Sending request to fal.ai');
+  setStatus('webhook', 'pending', 'Waiting for webhook');
+  updateDebugMessage('Submitting job to fal.ai...');
   let jobData;
+  let jobId = null;
+  let externalJobId = null;
+  let webhookUrl = null;
   try {
-    const jobRes = await fetch('/submit_job', {
+    const jobRes = await fetch('/submit_job_fal', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({ user_id: USER_ID, prompt, params: { image_url: imageUrl } })
+      body: JSON.stringify({
+        user_id: USER_ID,
+        prompt,
+        text_input: prompt,
+        image_url: imageUrl
+      })
     });
 
+    let payload;
+    try {
+      payload = await jobRes.json();
+    } catch (_) {
+      setStatus('queued', 'error', 'Invalid server response');
+      setStatus('fal_request', 'error', 'fal.ai submission failed');
+      setStatus('webhook', 'error', 'Webhook not scheduled');
+      throw new Error('Failed to parse response from server');
+    }
+
     if (jobRes.ok) {
-      jobData = await jobRes.json();
-      setStatus('queued', 'done', `Job #${jobData.id} queued`);
+      jobData = payload;
+      jobId = jobData.job_id ?? jobData.id ?? null;
+      externalJobId = jobData.external_job_id || jobData.request_id || null;
+      webhookUrl = jobData.webhook_url || null;
+      setStatus('queued', 'done', jobId ? `Job #${jobId} queued` : 'Job queued');
+      const requestMessage = externalJobId ? `Request ${externalJobId} queued` : 'Request queued';
+      setStatus('fal_request', 'done', requestMessage);
+      setStatus('webhook', 'active', 'Awaiting fal.ai webhook');
+      const details = [
+        jobId ? `Job #${jobId} queued on fal.ai.` : 'Job queued on fal.ai.',
+        externalJobId ? `Request ID: ${externalJobId}` : null,
+        webhookUrl ? `Webhook: ${webhookUrl}` : null
+      ].filter(Boolean).join(' ');
+      updateDebugMessage(details || 'Job queued.', 'success');
     } else {
       let detail = `${jobRes.status} ${jobRes.statusText}`;
-      try {
-        const payload = await jobRes.json();
-        if (payload && payload.error) {
-          detail = payload.error;
-        }
-      } catch (_) {}
+      if (payload && payload.error) {
+        detail = payload.error;
+      }
       setStatus('queued', 'error', 'Job submission failed');
+      setStatus('fal_request', 'error', 'fal.ai submission failed');
+      setStatus('webhook', 'error', 'Webhook not scheduled');
       throw new Error(detail);
     }
 
@@ -377,12 +437,18 @@ document.getElementById('job-form').addEventListener('submit', async (e) => {
 
     loadJobs();
   } catch (err) {
+    setStatus('queued', 'error', 'Job submission failed');
+    setStatus('fal_request', 'error', 'fal.ai submission failed');
+    setStatus('webhook', 'error', 'Webhook not scheduled');
     updateDebugMessage(`Job submission failed: ${normalizeError(err)}`, 'error');
     return;
   }
 
-  setStatus('summarizing', 'active', 'Fetching Wikipedia data');
-  updateDebugMessage(`Job #${jobData.id} submitted. Running Wikipedia scraping debug...`);
+  const summaryJobId = jobId ?? jobData?.id;
+  setStatus('summary', 'active', 'Fetching Wikipedia data with Ollama');
+  const submissionNote = summaryJobId ? `Job #${summaryJobId}` : 'Job';
+  const requestNote = externalJobId ? ` (request ${externalJobId})` : '';
+  updateDebugMessage(`${submissionNote}${requestNote} submitted. Running Wikipedia scraping debug...`);
 
   try {
     const summaryRes = await fetch('/wiki_summary', {
@@ -399,23 +465,32 @@ document.getElementById('job-form').addEventListener('submit', async (e) => {
           detail = payload.error;
         }
       } catch (_) {}
-      setStatus('summarizing', 'error', 'Summary failed');
-      setStatus('generating', 'pending', 'Waiting to start');
+      setStatus('summary', 'error', 'Summary failed');
+      setStatus('generation', 'pending', 'Waiting to start');
       throw new Error(detail);
     }
 
     const data = await summaryRes.json();
-    setStatus('summarizing', 'done', 'Summary generated');
-    renderScrapeResults(data, jobData.id);
+    setStatus('summary', 'done', 'Course script generated');
+    renderScrapeResults(data, summaryJobId);
   } catch (err) {
     updateDebugMessage(`Scraping debug failed: ${normalizeError(err)}`, 'error');
     return;
   }
 
-  setStatus('generating', 'active', 'Waiting for generation update');
+  setStatus('generation', 'active', 'Waiting for generation update');
+  setStatus('webhook', 'active', 'Waiting for fal.ai webhook');
   updateGenerationStatus('Awaiting video generation status...', 'active');
-  pollJobUntilComplete(jobData.id).catch((err) => {
-    setStatus('generating', 'error', 'Status check failed');
+  const pollJobId = summaryJobId ?? jobData.id;
+  if (pollJobId == null) {
+    setStatus('generation', 'error', 'Missing job identifier');
+    setStatus('webhook', 'error', 'Missing job identifier');
+    updateGenerationStatus('Cannot monitor job without an ID.', 'error');
+    return;
+  }
+  pollJobUntilComplete(pollJobId, { requestId: externalJobId }).catch((err) => {
+    setStatus('generation', 'error', 'Status check failed');
+    setStatus('webhook', 'error', 'Status check failed');
     updateGenerationStatus(`Failed to check job status: ${normalizeError(err)}`, 'error');
   });
 });

--- a/src/tests/test_app.py
+++ b/src/tests/test_app.py
@@ -173,7 +173,7 @@ def test_wiki_summary(monkeypatch):
     def fake_scrape(url):
         return "Python is a programming language.", None  # pragma: no cover
 
-    def fake_summary(text):
+    def fake_summary(text, topic_hint=None):
         return "summary"  # pragma: no cover
 
     monkeypatch.setattr(app_module, "extract_keywords", fake_extract)


### PR DESCRIPTION
## Summary
- rework the Ollama summarisation prompt to identify the learner's topic and deliver a course-style explainer script
- feed the original query into the summariser and expand the dashboard UI with provider/request columns plus detailed fal.ai/webhook status updates
- update the wiki summary test double to accept the new prompt signature

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c93a91b53c8327ba135a7b53cbabef