### PR TITLE
Log fal webhook payloads and surface them in the dashboard

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -293,6 +293,74 @@ def _merge_job_video_urls(jobs: list[dict[str, Any]]) -> None:
             job["video_url"] = url
 
 
+def _record_fal_webhook_event(
+    job_row: Mapping[str, Any],
+    *,
+    status: str | None,
+    request_id: str | None,
+    gateway_request_id: str | None,
+    raw_payload: Mapping[str, Any] | None,
+    result_payload: object,
+) -> dict[str, Any] | None:
+    """Persist the latest fal.ai webhook payload for debugging purposes."""
+
+    if supabase is None:
+        return None
+
+    job_id = _normalize_job_id(job_row.get("id"))
+    if job_id is None:
+        return None
+
+    params_dict = _coerce_mapping(job_row.get("params"))
+    new_params = dict(params_dict)
+
+    debug_section_raw = new_params.get("debug")
+    debug_section = _coerce_mapping(debug_section_raw) if debug_section_raw is not None else {}
+    debug_dict = dict(debug_section)
+
+    event: dict[str, Any] = {"received_at": current_timestamp()}
+    if status:
+        event["status"] = status
+    if request_id:
+        event["request_id"] = request_id
+    if gateway_request_id:
+        event["gateway_request_id"] = gateway_request_id
+    if raw_payload is not None:
+        event["raw_payload"] = raw_payload
+    if result_payload is not None:
+        event["content"] = result_payload
+
+    events_history_raw = debug_dict.get("webhook_events")
+    events_history: list[dict[str, Any]] = []
+    if isinstance(events_history_raw, Sequence) and not isinstance(
+        events_history_raw, (str, bytes, bytearray)
+    ):
+        for item in events_history_raw:
+            if isinstance(item, Mapping):
+                events_history.append(dict(item))
+            elif isinstance(item, str):
+                parsed = _coerce_mapping(item)
+                if parsed:
+                    events_history.append(dict(parsed))
+
+    events_history.append(event)
+    if len(events_history) > 20:
+        events_history = events_history[-20:]
+
+    debug_dict["webhook_events"] = events_history
+    debug_dict["last_webhook_event"] = events_history[-1]
+    new_params["debug"] = debug_dict
+
+    try:
+        supabase.table("jobs").update({"params": new_params}).eq("id", job_id).execute()
+    except Exception as exc:  # pragma: no cover - Supabase optional logging
+        app.logger.debug("Unable to persist webhook payload for job %s: %s", job_id, exc)
+        return None
+
+    job_row["params"] = new_params
+    return events_history[-1]
+
+
 def _extract_video_details(payload: object) -> tuple[str | None, dict[str, Any]]:
     """Return the first video URL and metadata found in *payload*."""
 
@@ -1323,12 +1391,36 @@ def fal_webhook():
 
         job = res.data[0]
         job_id = job["id"]
-        user_id = job["user_id"]
+
+        if request_id is not None and not isinstance(request_id, str):
+            request_id = str(request_id)
+        if gateway_request_id is not None and not isinstance(gateway_request_id, str):
+            gateway_request_id = str(gateway_request_id)
 
         if gateway_request_id and gateway_request_id != request_id:
             supabase.table("jobs").update({"external_job_id": gateway_request_id}).eq("id", job_id).execute()
 
         status_upper = (status or "").upper()
+        status_label = status_upper or (status if isinstance(status, str) else None)
+
+        log_message = (
+            f"fal.ai webhook update for job {job_id} "
+            f"(request={request_id or '?'} gateway={gateway_request_id or '?'} status={status_label or '?'})"
+        )
+        app.logger.info("%s payload=%s", log_message, payload)
+        try:
+            print(f"{log_message} payload={payload}", flush=True)
+        except Exception:  # pragma: no cover - printing best effort
+            pass
+
+        event_record = _record_fal_webhook_event(
+            job,
+            status=status_label,
+            request_id=request_id,
+            gateway_request_id=gateway_request_id,
+            raw_payload=payload,
+            result_payload=result_payload,
+        )
 
         if status_upper in {"SUCCESS", "OK", "COMPLETED"}:
             _finalize_fal_job_success(job, result_payload)
@@ -1358,7 +1450,17 @@ def fal_webhook():
         else:
             supabase.table("jobs").update({"status": "running"}).eq("id", job_id).execute()
 
-        return jsonify({"ok": True})
+        response_payload: dict[str, object] = {"ok": True, "job_id": job_id}
+        if status_label:
+            response_payload["status"] = status_label
+        if request_id:
+            response_payload["request_id"] = request_id
+        if gateway_request_id:
+            response_payload["gateway_request_id"] = gateway_request_id
+        if event_record:
+            response_payload["webhook_event"] = event_record
+
+        return jsonify(response_payload)
 
     except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -39,6 +39,11 @@
     <div id="scrape-debug" class="text-sm text-slate-300">
       Submit a prompt to trigger the Wikipedia scraping pipeline and the summary will be displayed here.
     </div>
+    <div class="mt-4 rounded-lg border border-slate-800 bg-slate-900/60 p-3">
+      <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Latest fal.ai webhook</p>
+      <p id="webhook-note" class="text-xs text-slate-400 mt-2">No webhook updates yet.</p>
+      <pre id="webhook-payload" class="mt-2 max-h-64 overflow-auto rounded bg-slate-950/80 p-3 text-xs text-slate-300">—</pre>
+    </div>
   </section>
   <div class="text-right">
     <button id="refresh-jobs" class="px-4 py-2 rounded bg-teal-500 hover:bg-teal-400 text-slate-900 font-semibold">Refresh Jobs</button>
@@ -58,12 +63,37 @@
     </thead>
     <tbody id="jobs-body"></tbody>
   </table>
+  <section class="mt-8 space-y-3">
+    <div class="flex items-center justify-between">
+      <h2 class="text-lg font-semibold text-slate-200">Generated videos</h2>
+      <button id="refresh-videos" class="px-4 py-2 rounded bg-indigo-500 hover:bg-indigo-400 text-slate-900 font-semibold">Refresh Videos</button>
+    </div>
+    <table class="min-w-full text-sm" id="videos-table">
+      <thead>
+        <tr class="text-left">
+          <th class="px-2 py-1">ID</th>
+          <th class="px-2 py-1">Title</th>
+          <th class="px-2 py-1">Source</th>
+          <th class="px-2 py-1">Job</th>
+          <th class="px-2 py-1">Created</th>
+        </tr>
+      </thead>
+      <tbody id="videos-body">
+        <tr>
+          <td class="px-2 py-2 text-slate-400" colspan="5">No videos loaded yet.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
 </div>
 <script>
 
 const USER_ID = {{ user_id | tojson }};
 const debugOutput = document.getElementById('scrape-debug');
 const statusOutput = document.getElementById('scrape-status');
+const webhookNote = document.getElementById('webhook-note');
+const webhookPayloadEl = document.getElementById('webhook-payload');
+const videosBody = document.getElementById('videos-body');
 const STATUS_STEPS = [
   { id: 'queued', label: 'Job queued' },
   { id: 'summary', label: 'Ollama summary' },
@@ -73,6 +103,138 @@ const STATUS_STEPS = [
 ];
 const statusElements = new Map();
 let pollSequence = 0;
+let activeJobId = null;
+
+function clearWebhookDisplay(message = 'No webhook updates yet.') {
+  if (webhookNote) {
+    webhookNote.textContent = message;
+    webhookNote.className = 'text-xs text-slate-400 mt-2';
+  }
+  if (webhookPayloadEl) {
+    webhookPayloadEl.textContent = '—';
+  }
+}
+
+function stringifyForDisplay(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch (_) {
+    return String(value);
+  }
+}
+
+function extractWebhookDebug(job) {
+  if (!job || typeof job !== 'object') {
+    return null;
+  }
+  let params = job.params;
+  if (!params || typeof params !== 'object') {
+    params = safeJsonParse(params);
+  }
+  if (!params || typeof params !== 'object') {
+    return null;
+  }
+  let debugInfo = params.debug || params.Debug || params.fal_debug || params.falDebug;
+  if (typeof debugInfo === 'string') {
+    debugInfo = safeJsonParse(debugInfo);
+  }
+  if (!debugInfo || typeof debugInfo !== 'object') {
+    return null;
+  }
+  return debugInfo;
+}
+
+function normalizeWebhookEvent(event) {
+  if (!event) return null;
+  if (typeof event === 'string') {
+    const parsed = safeJsonParse(event);
+    if (parsed && typeof parsed === 'object') {
+      return parsed;
+    }
+    return { raw: event };
+  }
+  if (typeof event === 'object') {
+    return event;
+  }
+  return null;
+}
+
+function extractLatestWebhookEvent(job) {
+  const debugInfo = extractWebhookDebug(job);
+  if (!debugInfo) {
+    return null;
+  }
+  let event = debugInfo.last_webhook_event || debugInfo.lastWebhookEvent;
+  if (!event) {
+    const history = Array.isArray(debugInfo.webhook_events)
+      ? debugInfo.webhook_events
+      : Array.isArray(debugInfo.webhookEvents)
+        ? debugInfo.webhookEvents
+        : null;
+    if (history && history.length) {
+      event = history[history.length - 1];
+    }
+  }
+  return normalizeWebhookEvent(event);
+}
+
+function renderWebhookEvent(job) {
+  if (!webhookNote || !webhookPayloadEl) {
+    return;
+  }
+  if (!job) {
+    clearWebhookDisplay('No job selected.');
+    return;
+  }
+  const event = extractLatestWebhookEvent(job);
+  if (!event) {
+    const label = job.id != null ? `job #${job.id}` : 'this job';
+    clearWebhookDisplay(`No webhook updates recorded for ${label} yet.`);
+    return;
+  }
+
+  const statusValue = typeof event.status === 'string' ? event.status : '';
+  const statusLower = statusValue.toLowerCase();
+  let noteClass = 'text-xs text-slate-300 mt-2';
+  if (statusLower.includes('fail') || statusLower.includes('error') || statusLower.includes('cancel')) {
+    noteClass = 'text-xs text-red-300 mt-2';
+  } else if (statusLower.includes('success') || statusLower.includes('ok') || statusLower.includes('complete')) {
+    noteClass = 'text-xs text-emerald-300 mt-2';
+  } else if (statusLower.includes('progress') || statusLower.includes('queue')) {
+    noteClass = 'text-xs text-amber-200 mt-2';
+  }
+  webhookNote.className = noteClass;
+
+  const details = [];
+  if (statusValue) {
+    details.push(`Status: ${statusValue}`);
+  }
+  const receivedAt = event.received_at || event.receivedAt;
+  if (receivedAt) {
+    details.push(`Received at ${receivedAt}`);
+  }
+  const reqId = event.request_id || event.requestId || job.external_job_id || job.externalJobId;
+  if (reqId) {
+    details.push(`Request ${reqId}`);
+  }
+  const gatewayId = event.gateway_request_id || event.gatewayRequestId;
+  if (gatewayId) {
+    details.push(`Gateway ${gatewayId}`);
+  }
+  webhookNote.textContent = details.length ? details.join(' • ') : 'Webhook update received.';
+
+  const payloadForDisplay =
+    event.content ?? event.raw_payload ?? event.payload ?? event;
+  webhookPayloadEl.textContent = stringifyForDisplay(payloadForDisplay);
+}
+
+clearWebhookDisplay();
 
 function updateDebugMessage(message, tone = 'info') {
   if (!debugOutput) return;
@@ -368,9 +530,37 @@ function showGenerationVideoLinks(videoUrl) {
 }
 
 async function loadJobs() {
-  const res = await fetch(`/list_jobs/${USER_ID}`, { cache: 'no-store' });
-  const jobs = await res.json();
   const body = document.getElementById('jobs-body');
+  if (!body) {
+    return [];
+  }
+
+  let jobs = [];
+  try {
+    const res = await fetch(`/list_jobs/${USER_ID}`, { cache: 'no-store' });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    const payload = await res.json();
+    if (!Array.isArray(payload)) {
+      throw new Error('Unexpected jobs payload');
+    }
+    jobs = payload;
+  } catch (err) {
+    const message = `Failed to load jobs: ${normalizeError(err)}`;
+    body.innerHTML = `<tr><td class="px-2 py-2 text-sm text-red-300" colspan="8">${escapeHtml(message)}</td></tr>`;
+    clearWebhookDisplay(message);
+    return [];
+  }
+
+  if (!jobs.length) {
+    body.innerHTML = '<tr><td class="px-2 py-2 text-slate-400" colspan="8">No jobs yet.</td></tr>';
+    if (activeJobId == null) {
+      clearWebhookDisplay('No jobs found yet.');
+    }
+    return jobs;
+  }
+
   body.innerHTML = '';
   jobs.forEach(job => {
     const tr = document.createElement('tr');
@@ -381,16 +571,17 @@ async function loadJobs() {
       videoLinks = `<a href="${escapedUrl}" target="_blank" rel="noopener" class="text-teal-400 underline">View</a>`+
                    ` <a href="${escapedUrl}" download class="text-teal-400 underline ml-2">Download</a>`;
     }
-    const provider = job.provider || '—';
-    const requestId = job.external_job_id || '—';
-    const promptText = job.prompt || '';
-    const submittedAt = job.submitted_at || '—';
-    const statusText = job.status || '—';
+    const provider = escapeHtml(job.provider || '—');
+    const requestId = escapeHtml(job.external_job_id || '—');
+    const promptText = escapeHtml(job.prompt || '');
+    const submittedAt = escapeHtml(job.submitted_at || '—');
+    const statusText = escapeHtml(job.status || '—');
+    const jobIdCell = job.id != null ? escapeHtml(String(job.id)) : '—';
     const { short: errorShort, full: errorFull } = formatJobErrorDetail(job.error);
     const errorCell = errorFull
       ? `<span title="${escapeHtml(errorFull)}">${escapeHtml(errorShort)}</span>`
       : '—';
-    tr.innerHTML = `<td class="px-2 py-1">${job.id}</td>`+
+    tr.innerHTML = `<td class="px-2 py-1">${jobIdCell}</td>`+
                    `<td class="px-2 py-1">${promptText}</td>`+
                    `<td class="px-2 py-1">${provider}</td>`+
                    `<td class="px-2 py-1">${requestId}</td>`+
@@ -400,6 +591,68 @@ async function loadJobs() {
                    `<td class="px-2 py-1">${videoLinks}</td>`;
     body.appendChild(tr);
   });
+
+  const targetJob =
+    activeJobId != null ? jobs.find(job => job.id === activeJobId) : jobs[0];
+  if (targetJob) {
+    renderWebhookEvent(targetJob);
+  } else {
+    clearWebhookDisplay('No webhook updates yet.');
+  }
+
+  return jobs;
+}
+
+async function loadVideos() {
+  if (!videosBody) {
+    return [];
+  }
+
+  let videos = [];
+  try {
+    const res = await fetch(`/get_videos/${USER_ID}`, { cache: 'no-store' });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    const payload = await res.json();
+    if (!Array.isArray(payload)) {
+      throw new Error('Unexpected videos payload');
+    }
+    videos = payload;
+  } catch (err) {
+    const message = `Failed to load videos: ${normalizeError(err)}`;
+    videosBody.innerHTML = `<tr><td class="px-2 py-2 text-sm text-red-300" colspan="5">${escapeHtml(message)}</td></tr>`;
+    return [];
+  }
+
+  if (!videos.length) {
+    videosBody.innerHTML = '<tr><td class="px-2 py-2 text-slate-400" colspan="5">No videos yet.</td></tr>';
+    return videos;
+  }
+
+  videosBody.innerHTML = '';
+  videos.forEach(video => {
+    const tr = document.createElement('tr');
+    const idCell = video.id != null ? escapeHtml(String(video.id)) : '—';
+    const titleCell = escapeHtml(video.title || 'Video');
+    const jobId = video.job_id != null ? escapeHtml(String(video.job_id)) : '—';
+    const createdAt = escapeHtml(video.created_at || '—');
+    const sourceUrl = typeof video.source_url === 'string' ? video.source_url : '';
+    let sourceLinks = '—';
+    if (sourceUrl) {
+      const safeUrl = escapeHtml(sourceUrl);
+      sourceLinks = `<a href="${safeUrl}" target="_blank" rel="noopener" class="text-teal-400 underline">View</a>`+
+                    ` <a href="${safeUrl}" download class="text-teal-400 underline ml-2">Download</a>`;
+    }
+    tr.innerHTML = `<td class="px-2 py-1">${idCell}</td>`+
+                   `<td class="px-2 py-1">${titleCell}</td>`+
+                   `<td class="px-2 py-1">${sourceLinks}</td>`+
+                   `<td class="px-2 py-1">${jobId}</td>`+
+                   `<td class="px-2 py-1">${createdAt}</td>`;
+    videosBody.appendChild(tr);
+  });
+
+  return videos;
 }
 
 async function pollJobUntilComplete(jobId, options = {}) {
@@ -407,6 +660,7 @@ async function pollJobUntilComplete(jobId, options = {}) {
   const sequence = ++pollSequence;
   let lastStatus = null;
   let knownRequestId = requestId;
+  activeJobId = jobId;
 
   for (let attempt = 0; maxAttempts == null || attempt < maxAttempts; attempt += 1) {
     if (sequence !== pollSequence) {
@@ -452,8 +706,11 @@ async function pollJobUntilComplete(jobId, options = {}) {
     if (!job) {
       setStatus('webhook', 'active', 'Waiting for Supabase record');
       updateGenerationStatus(`Waiting for job #${jobId} to appear in Supabase…`, 'active');
+      clearWebhookDisplay(`Waiting for job #${jobId} to appear in Supabase…`);
       continue;
     }
+
+    renderWebhookEvent(job);
 
     if (job.status !== lastStatus) {
       lastStatus = job.status;
@@ -477,7 +734,9 @@ async function pollJobUntilComplete(jobId, options = {}) {
       if (videoUrl) {
         showGenerationVideoLinks(videoUrl);
       }
+      renderWebhookEvent(job);
       loadJobs();
+      loadVideos();
       return;
     }
 
@@ -500,6 +759,7 @@ async function pollJobUntilComplete(jobId, options = {}) {
         error: errorFull || job.error || null
       });
       updateGenerationStatus(statusNote, 'error');
+      renderWebhookEvent(job);
       loadJobs();
       return;
     }
@@ -528,6 +788,7 @@ async function pollJobUntilComplete(jobId, options = {}) {
     setStatus('webhook', 'error', 'Timed out waiting for webhook');
     setStatus('generation', 'error', 'Timed out');
     updateGenerationStatus('Timed out waiting for video generation to finish.', 'error');
+    clearWebhookDisplay(`Timed out waiting for webhook updates for job #${jobId}.`);
   }
 }
 
@@ -540,6 +801,7 @@ document.getElementById('job-form').addEventListener('submit', async (e) => {
   setStatus('fal_request', 'active', 'Sending request to fal.ai');
   setStatus('webhook', 'pending', 'Waiting for webhook');
   updateDebugMessage('Submitting job to fal.ai...');
+  clearWebhookDisplay('Submitting job to fal.ai…');
   let jobData;
   let jobId = null;
   let externalJobId = null;
@@ -571,6 +833,9 @@ document.getElementById('job-form').addEventListener('submit', async (e) => {
       jobId = jobData.job_id ?? jobData.id ?? null;
       externalJobId = jobData.external_job_id || jobData.request_id || null;
       webhookUrl = jobData.webhook_url || null;
+      if (jobId != null) {
+        activeJobId = jobId;
+      }
       setStatus('queued', 'done', jobId ? `Job #${jobId} queued` : 'Job queued');
       const requestMessage = externalJobId ? `Request ${externalJobId} queued` : 'Request queued';
       setStatus('fal_request', 'done', requestMessage);
@@ -581,6 +846,10 @@ document.getElementById('job-form').addEventListener('submit', async (e) => {
         webhookUrl ? `Webhook: ${webhookUrl}` : null
       ].filter(Boolean).join(' ');
       updateDebugMessage(details || 'Job queued.', 'success');
+      const waitingMessage = jobId
+        ? `Waiting for webhook updates for job #${jobId}…`
+        : 'Waiting for webhook updates…';
+      clearWebhookDisplay(waitingMessage);
     } else {
       let detail = `${jobRes.status} ${jobRes.statusText}`;
       if (payload && payload.error) {
@@ -589,6 +858,7 @@ document.getElementById('job-form').addEventListener('submit', async (e) => {
       setStatus('queued', 'error', 'Job submission failed');
       setStatus('fal_request', 'error', 'fal.ai submission failed');
       setStatus('webhook', 'error', 'Webhook not scheduled');
+      clearWebhookDisplay(`Job submission failed: ${detail}`);
       throw new Error(detail);
     }
 
@@ -602,6 +872,7 @@ document.getElementById('job-form').addEventListener('submit', async (e) => {
     setStatus('fal_request', 'error', 'fal.ai submission failed');
     setStatus('webhook', 'error', 'Webhook not scheduled');
     updateDebugMessage(`Job submission failed: ${normalizeError(err)}`, 'error');
+    clearWebhookDisplay(`Job submission failed: ${normalizeError(err)}`);
     return;
   }
 
@@ -647,12 +918,14 @@ document.getElementById('job-form').addEventListener('submit', async (e) => {
     setStatus('generation', 'error', 'Missing job identifier');
     setStatus('webhook', 'error', 'Missing job identifier');
     updateGenerationStatus('Cannot monitor job without an ID.', 'error');
+    clearWebhookDisplay('Cannot monitor job without an ID.');
     return;
   }
   pollJobUntilComplete(pollJobId, { requestId: externalJobId }).catch((err) => {
     setStatus('generation', 'error', 'Status check failed');
     setStatus('webhook', 'error', 'Status check failed');
     updateGenerationStatus(`Failed to check job status: ${normalizeError(err)}`, 'error');
+    clearWebhookDisplay(`Failed to check job status: ${normalizeError(err)}`);
   });
 });
 
@@ -661,9 +934,15 @@ if (refreshButton) {
   refreshButton.addEventListener('click', loadJobs);
 }
 
+const refreshVideosButton = document.getElementById('refresh-videos');
+if (refreshVideosButton) {
+  refreshVideosButton.addEventListener('click', loadVideos);
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   initStatusUI();
   loadJobs();
+  loadVideos();
 });
 
 </script>

--- a/src/tests/test_fal.py
+++ b/src/tests/test_fal.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 import time
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -134,6 +135,15 @@ def test_fal_webhook_verification(monkeypatch):
     )
 
     assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "OK"
+    assert data["request_id"] == "req-1"
+    webhook_event = data.get("webhook_event")
+    assert webhook_event
+    assert webhook_event["status"] == "OK"
+    assert webhook_event["request_id"] == "req-1"
+    content = webhook_event.get("content") or {}
+    assert content.get("video", {}).get("url") == "http://cdn/video.mp4"
     assert called["headers"]["X-Fal-Webhook-Request-Id"] == "req-1"
     assert isinstance(called["body"], (bytes, bytearray))
     assert b"req-1" in called["body"]
@@ -149,9 +159,24 @@ def test_fal_webhook_verification(monkeypatch):
         if rec.op == "update" and rec.table == "jobs" and "params" in rec.payload
     ]
     assert param_updates
-    fal_result = param_updates[0].payload["params"].get("fal_result")
-    assert fal_result and fal_result["video"]["url"] == "http://cdn/video.mp4"
+    params_payloads = [rec.payload["params"] for rec in param_updates]
+
+    fal_payloads = [p for p in params_payloads if p.get("fal_result")]
+    assert fal_payloads
+    fal_result = fal_payloads[-1]["fal_result"]
+    assert fal_result["video"]["url"] == "http://cdn/video.mp4"
     assert fal_result["payload"]["video"]["url"] == "http://cdn/video.mp4"
+
+    debug_payloads = [p.get("debug") for p in params_payloads if p.get("debug")]
+    assert debug_payloads
+    latest_debug = debug_payloads[-1]
+    if isinstance(latest_debug, str):
+        latest_debug = json.loads(latest_debug)
+    last_event = latest_debug.get("last_webhook_event") or {}
+    assert last_event.get("status") == "OK"
+    assert last_event.get("request_id") == "req-1"
+    last_content = last_event.get("content") or {}
+    assert last_content.get("video", {}).get("url") == "http://cdn/video.mp4"
 
 
 def test_fal_webhook_rejects_invalid_signature(monkeypatch):


### PR DESCRIPTION
## Summary
- persist the latest fal.ai webhook payload in Supabase, log it, and expose metadata in the webhook response
- show the most recent webhook event and generated videos in the dashboard with refresh controls
- update tests to cover the new webhook debug information

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c96198b5e48327aed3de29ddcb7d3e