### PR TITLE
Refactor webhook flow for fal job UUIDs

### DIFF
--- a/src/tests/_supabase_dummy.py
+++ b/src/tests/_supabase_dummy.py
@@ -80,8 +80,11 @@ class _DummyInsert:
         record = dict(self.payload)
         if self.table in self.supabase.next_ids and "id" not in record:
             next_id = self.supabase.next_ids[self.table]
-            record["id"] = next_id
             self.supabase.next_ids[self.table] = next_id + 1
+            if self.table in {"jobs", "videos"}:
+                record["id"] = f"{self.table}-{next_id}"
+            else:
+                record["id"] = next_id
         self.supabase.records.append(_Record("insert", self.table, record))
         return type("Resp", (), {"data": [record]})()
 

--- a/src/tests/test_app.py
+++ b/src/tests/test_app.py
@@ -318,7 +318,7 @@ def test_list_jobs_includes_video_url(monkeypatch):
         "jobs",
         [
             {
-                "id": 1,
+                "id": "job-1",
                 "user_id": "user-123",
                 "status": "succeeded",
                 "params": {"fal_result": {"video": {"url": "https://fallback"}}},
@@ -329,7 +329,7 @@ def test_list_jobs_includes_video_url(monkeypatch):
         "videos",
         [
             {
-                "job_id": 1,
+                "job_id": "job-1",
                 "source_url": "https://cdn.example.com/video.mp4",
             }
         ],
@@ -351,7 +351,7 @@ def test_get_job_returns_video_url(monkeypatch):
         "jobs",
         [
             {
-                "id": 42,
+                "id": "job-42",
                 "user_id": "user-456",
                 "status": "running",
                 "params": {"fal_result": {"video": {"url": "https://fallback"}}},
@@ -362,18 +362,18 @@ def test_get_job_returns_video_url(monkeypatch):
         "videos",
         [
             {
-                "job_id": 42,
+                "job_id": "job-42",
                 "source_url": "https://cdn.example.com/video-42.mp4",
             }
         ],
     )
     monkeypatch.setattr(app_module, "supabase", dummy_supabase)
 
-    resp = client.get("/job/42")
+    resp = client.get("/job/job-42")
 
     assert resp.status_code == 200
     job = resp.get_json()
-    assert job["id"] == 42
+    assert job["id"] == "job-42"
     assert job["video_url"] == "https://cdn.example.com/video-42.mp4"
 
 

--- a/src/tests/test_worker.py
+++ b/src/tests/test_worker.py
@@ -35,7 +35,7 @@ def test_process_video_job_inserts_file(monkeypatch):
         "jobs",
         [
             {
-                "id": 1,
+                "id": "job-1",
                 "user_id": 7,
                 "prompt": "hello",
                 "params": {"image_url": "http://example.com/img.png"},
@@ -58,7 +58,7 @@ def test_process_video_job_inserts_file(monkeypatch):
     monkeypatch.setattr(worker_module.fal_client, "submit", fake_submit)
     monkeypatch.setattr(worker_module.fal_client, "result", fake_result)
 
-    worker_module.process_video_job(1)
+    worker_module.process_video_job("job-1")
 
     file_inserts = [rec for rec in dummy_supabase.records if rec.op == "insert" and rec.table == "files"]
     assert file_inserts

--- a/worker.py
+++ b/worker.py
@@ -56,7 +56,7 @@ def _deserialize_params(raw: Any) -> dict[str, Any]:
     return {}
 
 
-def _update_job(job_id: int, payload: dict[str, Any]) -> None:
+def _update_job(job_id: str | int, payload: dict[str, Any]) -> None:
     """Met à jour un job en ignorant silencieusement les erreurs réseau."""
 
     if supabase is None:
@@ -68,7 +68,7 @@ def _update_job(job_id: int, payload: dict[str, Any]) -> None:
 
 
 @celery.task(name="process_video_job")
-def process_video_job(job_id: int) -> None:
+def process_video_job(job_id: str | int) -> None:
     """Tâche Celery qui appelle fal.ai puis met à jour Supabase via REST."""
 
     if supabase is None:
@@ -154,7 +154,7 @@ def process_video_job(job_id: int) -> None:
             file_id = None
 
     video_payload: dict[str, Any] = {
-        "job_id": job_id,
+        "job_id": str(job_id),
         "user_id": user_id,
         "title": prompt or "fal.ai video",
         "duration_seconds": 5.0,


### PR DESCRIPTION
## Summary
- update fal webhook verification to use cached JWKS with PyNaCl hex keys
- remove the queue polling fallback in favour of webhook-only updates and support UUID job ids across the app
- adjust the worker and test doubles to use string-based job identifiers and refresh tests accordingly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9844fc1b8832791f5a0aabc2fe5a9