### PR TITLE
Send flattened fal.ai payloads from worker

### DIFF
--- a/src/app_test.py
+++ b/src/app_test.py
@@ -5,6 +5,7 @@ import requests
 FAL_KEY = os.getenv("FAL_KEY", "3e9ddf21-a57e-4b69-9eb9-2d9d336acf92:0296b68b75feab14420a58c753385b05")
 FAL_QUEUE_BASE = os.getenv("FAL_QUEUE_BASE", "https://queue.fal.run")
 MODEL = os.getenv("MODEL_DEFAULT", "fal-ai/infinitalk/single-text")
+WEBHOOK_URL = os.getenv("FAL_WEBHOOK_URL", "https://example.com/webhooks/fal")
 
 fal_input = {
     "prompt": "un professeur donne un cours en souriant",
@@ -14,7 +15,8 @@ fal_input = {
     "num_frames": 145,
     "resolution": "480p",
     "seed": 42,
-    "acceleration": "regular",
+    "acceleration": "high",
+    "webhook_url": WEBHOOK_URL,
 }
 
 headers = {
@@ -22,9 +24,7 @@ headers = {
     "Content-Type": "application/json",
 }
 
-payload = {
-    "input": fal_input,
-}
+payload = fal_input
 
 url = f"{FAL_QUEUE_BASE}/{MODEL}"
 

--- a/src/fal_client.py
+++ b/src/fal_client.py
@@ -28,9 +28,7 @@ def _normalize_input(input_data: str | Mapping[str, Any]) -> dict[str, Any]:
 
     if isinstance(input_data, Mapping):
         normalized: dict[str, Any] = {
-            key: value
-            for key, value in input_data.items()
-            if value is not None and key != "webhook_url"
+            key: value for key, value in input_data.items() if value is not None
         }
     else:
         normalized = {"prompt": input_data}
@@ -41,7 +39,7 @@ def submit_text2video(
     model_id: str,
     input_data: str | Mapping[str, Any],
 ) -> str:
-    payload: dict[str, object] = {"input": _normalize_input(input_data)}
+    payload: dict[str, object] = _normalize_input(input_data)
     endpoint = f"{FAL_QUEUE_BASE.rstrip('/')}/{model_id.lstrip('/')}"
     r = requests.post(
         endpoint,
@@ -270,10 +268,10 @@ async def status_async(
 
 # Backwards compatibility helpers used by worker.py tests
 def submit(model_id: str, arguments: dict):  # pragma: no cover - simple wrapper
-    input_args = arguments.get("input")
-    if input_args is None:
-        input_args = {k: v for k, v in arguments.items() if k != "webhook_url"}
-    req_id = submit_text2video(model_id, input_args)
+    payload = arguments.get("input")
+    if payload is None:
+        payload = {k: v for k, v in arguments.items() if k != "input"}
+    req_id = submit_text2video(model_id, payload)
     return type("Handle", (), {"request_id": req_id})()
 
 

--- a/src/tests/test_fal_client.py
+++ b/src/tests/test_fal_client.py
@@ -57,14 +57,17 @@ def test_submit_text2video_flattens_payload(capture_post):
         {
             "prompt": "hello",
             "voice": "Brian",
+            "webhook_url": "https://example.com/webhooks/fal",
         },
     )
 
     assert req_id == "req-123"
     payload = json.loads(capture_post["data"])
-    assert payload["input"]["prompt"] == "hello"
-    assert payload["input"]["voice"] == "Brian"
-    assert "webhook_url" not in payload["input"]
+    assert payload == {
+        "prompt": "hello",
+        "voice": "Brian",
+        "webhook_url": "https://example.com/webhooks/fal",
+    }
     assert capture_post["headers"].get("Authorization", "").startswith("Key ")
 
 
@@ -75,7 +78,7 @@ def test_submit_text2video_accepts_string_input(capture_post):
     )
 
     payload = json.loads(capture_post["data"])
-    assert payload == {"input": {"prompt": "a smiling teacher"}}
+    assert payload == {"prompt": "a smiling teacher"}
 
 
 @pytest.mark.anyio("asyncio")

--- a/worker.py
+++ b/worker.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
+from time import sleep
 from typing import Any
 
 from celery import Celery
 from dotenv import load_dotenv
+from requests import exceptions as requests_exceptions
 from supabase import Client, create_client
 
 import fal_client
@@ -35,6 +38,11 @@ if SUPABASE_URL and SUPABASE_KEY:
         supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
     except Exception:  # pragma: no cover - configuration invalide
         supabase = None
+
+
+DEFAULT_FAL_MODEL_ID = os.getenv(
+    "MODEL_DEFAULT", "fal-ai/infinitalk/single-text"
+)
 
 
 def _now_iso() -> str:
@@ -67,6 +75,108 @@ def _update_job(job_id: str | int, payload: dict[str, Any]) -> None:
         pass
 
 
+def _extract_error_message(payload: Any) -> str | None:
+    """Retourne un message d'erreur lisible depuis *payload*."""
+
+    if isinstance(payload, Mapping):
+        for key in ("error", "detail", "message"):
+            value = payload.get(key)
+            if isinstance(value, str):
+                stripped = value.strip()
+                if stripped:
+                    return stripped
+            nested = _extract_error_message(value)
+            if nested:
+                return nested
+        for value in payload.values():
+            nested = _extract_error_message(value)
+            if nested:
+                return nested
+    elif isinstance(payload, Sequence) and not isinstance(payload, (str, bytes, bytearray)):
+        for item in payload:
+            nested = _extract_error_message(item)
+            if nested:
+                return nested
+    elif isinstance(payload, str):
+        stripped = payload.strip()
+        if stripped:
+            return stripped
+    return None
+
+
+def _extract_status_label(payload: Any) -> str | None:
+    """Localise un libellé de statut dans *payload*."""
+
+    if isinstance(payload, Mapping):
+        for key in ("status", "state", "phase", "stage"):
+            value = payload.get(key)
+            if isinstance(value, str):
+                stripped = value.strip()
+                if stripped:
+                    return stripped
+            nested = _extract_status_label(value)
+            if nested:
+                return nested
+        for value in payload.values():
+            nested = _extract_status_label(value)
+            if nested:
+                return nested
+    elif isinstance(payload, Sequence) and not isinstance(payload, (str, bytes, bytearray)):
+        for item in payload:
+            nested = _extract_status_label(item)
+            if nested:
+                return nested
+    elif isinstance(payload, str):
+        stripped = payload.strip()
+        if stripped:
+            return stripped
+    return None
+
+
+def _extract_video_payload(payload: Any) -> dict[str, Any] | None:
+    """Retourne les métadonnées vidéo à partir d'une réponse fal.ai."""
+
+    if isinstance(payload, Mapping):
+        video_entry = payload.get("video")
+        if isinstance(video_entry, Mapping):
+            url = video_entry.get("url")
+            if isinstance(url, str) and url.strip():
+                return dict(video_entry)
+        elif isinstance(video_entry, str) and video_entry.strip():
+            return {"url": video_entry.strip()}
+
+        direct_url = payload.get("url")
+        if isinstance(direct_url, str) and direct_url.strip():
+            return {"url": direct_url.strip()}
+
+        for key in (
+            "payload",
+            "response",
+            "result",
+            "data",
+            "output",
+            "outputs",
+            "videos",
+            "items",
+            "files",
+            "assets",
+        ):
+            nested = payload.get(key)
+            video_payload = _extract_video_payload(nested)
+            if video_payload:
+                return video_payload
+    elif isinstance(payload, Sequence) and not isinstance(payload, (str, bytes, bytearray)):
+        for item in payload:
+            video_payload = _extract_video_payload(item)
+            if video_payload:
+                return video_payload
+    elif isinstance(payload, str):
+        stripped = payload.strip()
+        if stripped:
+            return {"url": stripped}
+    return None
+
+
 @celery.task(name="process_video_job")
 def process_video_job(job_id: str | int) -> None:
     """Tâche Celery qui appelle fal.ai puis met à jour Supabase via REST."""
@@ -89,18 +199,57 @@ def process_video_job(job_id: str | int) -> None:
         return
 
     job = res.data[0]
-    prompt = job.get("prompt") or ""
+    prompt_value = job.get("prompt")
+    if not isinstance(prompt_value, str):
+        prompt_value = ""
+    prompt = prompt_value
+    prompt_clean = prompt_value.strip()
     params = _deserialize_params(job.get("params"))
-    image_url = params.get("image_url")
     user_id = job.get("user_id")
 
-    arguments: dict[str, Any] = {"prompt": prompt}
-    if image_url:
-        arguments["image_url"] = image_url
+    fal_arguments = {
+        key: value
+        for key, value in _deserialize_params(params.get("fal_input")).items()
+        if value is not None
+    }
+
+    image_url_value = params.get("image_url")
+    image_url = image_url_value.strip() if isinstance(image_url_value, str) else ""
+    text_input_value = params.get("text_input")
+    text_input = (
+        text_input_value.strip() if isinstance(text_input_value, str) else ""
+    )
+
+    if image_url and "image_url" not in fal_arguments:
+        fal_arguments["image_url"] = image_url
+    if text_input and "text_input" not in fal_arguments:
+        fal_arguments["text_input"] = text_input
+
+    existing_prompt = fal_arguments.get("prompt")
+    if not isinstance(existing_prompt, str) or not existing_prompt.strip():
+        if prompt_clean:
+            fal_arguments["prompt"] = prompt_clean
+        else:
+            fal_arguments["prompt"] = prompt
+
+    webhook_override = params.get("webhook_url")
+    if isinstance(webhook_override, str):
+        webhook_clean = webhook_override.strip()
+        if webhook_clean and "webhook_url" not in fal_arguments:
+            fal_arguments["webhook_url"] = webhook_clean
+
+    fal_model_id_value = params.get("model_id")
+    fal_model_id = (
+        fal_model_id_value.strip()
+        if isinstance(fal_model_id_value, str)
+        else ""
+    )
+    if not fal_model_id:
+        fal_model_id = DEFAULT_FAL_MODEL_ID
 
     try:
         handle = fal_client.submit(
-            "fal-ai/minimax-video/image-to-video", arguments=arguments
+            fal_model_id, arguments=fal_arguments
         )
         request_id = getattr(handle, "request_id", None)
     except Exception as exc:
@@ -120,23 +269,72 @@ def process_video_job(job_id: str | int) -> None:
         },
     )
 
-    try:
-        response = fal_client.result(
-            "fal-ai/minimax-video/image-to-video", request_id
-        )
-    except Exception as exc:
-        _update_job(job_id, {"status": "failed", "error": str(exc)})
-        raise
+    success_states = {"SUCCESS", "SUCCEEDED", "COMPLETED", "DONE", "OK"}
+    failure_states = {"FAILED", "ERROR", "CANCELLED", "CANCELED"}
+    transient_status_codes = {202, 425}
 
-    video_url: str | None = None
-    if isinstance(response, dict):
-        video = response.get("video")
-        if isinstance(video, dict):
-            video_url = video.get("url")
-        elif isinstance(video, str):
-            video_url = video
-        else:
-            video_url = response.get("url")
+    attempts = 0
+    consecutive_errors = 0
+    response: dict[str, Any] | None = None
+    fal_video_payload: dict[str, Any] | None = None
+
+    while attempts < 60:
+        attempts += 1
+        try:
+            response = fal_client.result(fal_model_id, request_id)
+        except requests_exceptions.HTTPError as exc:
+            response_obj = getattr(exc, "response", None)
+            status_code = getattr(response_obj, "status_code", None)
+            if status_code in transient_status_codes:
+                consecutive_errors = 0
+                sleep(5)
+                continue
+            consecutive_errors += 1
+            if consecutive_errors >= 3:
+                _update_job(job_id, {"status": "failed", "error": str(exc)})
+                raise
+            sleep(5)
+            continue
+        except Exception as exc:
+            consecutive_errors += 1
+            if consecutive_errors >= 3:
+                _update_job(job_id, {"status": "failed", "error": str(exc)})
+                raise
+            sleep(5)
+            continue
+
+        consecutive_errors = 0
+        status_label = _extract_status_label(response)
+        status_upper = status_label.upper() if status_label else ""
+
+        if status_upper in failure_states:
+            error_message = _extract_error_message(response) or (
+                f"fal.ai request failed with status {status_upper}"
+            )
+            _update_job(job_id, {"status": "failed", "error": error_message})
+            raise RuntimeError(error_message)
+
+        fal_video_payload = _extract_video_payload(response)
+        if fal_video_payload and isinstance(fal_video_payload.get("url"), str):
+            break
+
+        if status_upper and status_upper not in success_states:
+            sleep(5)
+            continue
+
+        # Statut de succès mais pas de vidéo → on sort pour signaler l'erreur.
+        break
+
+    if not fal_video_payload or not isinstance(fal_video_payload.get("url"), str):
+        message = "fal.ai video result not available"
+        _update_job(job_id, {"status": "failed", "error": message})
+        raise RuntimeError(message)
+
+    video_url = fal_video_payload["url"].strip()
+    if not video_url:
+        message = "fal.ai video result not available"
+        _update_job(job_id, {"status": "failed", "error": message})
+        raise RuntimeError(message)
 
     file_id: int | None = None
     if video_url:


### PR DESCRIPTION
## Summary
- submit fal.ai jobs from the worker using the stored fal_input/model_id and keep webhook URLs intact
- flatten fal.ai submission payloads so fields are sent at the top level instead of under an input wrapper
- refresh worker, client tests, and the sample script to exercise the new request shape

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b52bf71c8327bd66452fc134f48e