### PR TITLE
Improve debug logging for fal result payloads

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -48,7 +48,18 @@ def debug_log(func):
             print(f"        kwargs={kwargs}")
         try:
             result = func(*args, **kwargs)
-            print(f"[DEBUG] <<< {func.__name__} returned {type(result)}")
+            if isinstance(result, Mapping):
+                try:
+                    serialized = json.dumps(
+                        result, ensure_ascii=False, indent=2, sort_keys=True
+                    )
+                except TypeError:
+                    serialized = repr(result)
+                print(
+                    f"[DEBUG] <<< {func.__name__} returned dict:\n{serialized}"
+                )
+            else:
+                print(f"[DEBUG] <<< {func.__name__} returned {type(result)}")
             return result
         except Exception as e:
             print(f"[DEBUG] !!! {func.__name__} raised {e}")


### PR DESCRIPTION
## Summary
- pretty-print mapping results in the debug_log decorator so get_result payloads are visible in the logs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9c386a1348327aa213b3dbe100e16