### PR TITLE
Switch default fal.ai model to veo3 fast

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -85,7 +85,7 @@ app = Flask(__name__)
 app.secret_key = os.getenv("FLASK_SECRET", "dev-secret-change-me")
 app.config["JSONIFY_PRETTYPRINT_REGULAR"] = False
 
-MODEL_DEFAULT = os.getenv("MODEL_DEFAULT")
+MODEL_DEFAULT = os.getenv("MODEL_DEFAULT", "fal-ai/veo3/fast")
 
 
 def _env_float(name: str, default: float) -> float:

--- a/src/app_test.py
+++ b/src/app_test.py
@@ -11,7 +11,7 @@ FAL_KEY = os.getenv(
     "FAL_KEY", "3e9ddf21-a57e-4b69-9eb9-2d9d336acf92:0296b68b75feab14420a58c753385b05"
 )
 FAL_QUEUE_BASE = os.getenv("FAL_QUEUE_BASE", "https://queue.fal.run")
-MODEL = os.getenv("MODEL_DEFAULT", "fal-ai/ai-avatar/single-text")
+MODEL = os.getenv("MODEL_DEFAULT", "fal-ai/veo3/fast")
 
 
 def _default_payload() -> dict[str, Any]:

--- a/src/tests/test_app.py
+++ b/src/tests/test_app.py
@@ -399,7 +399,7 @@ def test_fal_status_endpoint_returns_logs_and_result(monkeypatch):
             {
                 "id": "job-200",
                 "external_job_id": "req-200",
-                "params": {"model_id": "fal-ai/infinitalk/single-text"},
+                "params": {"model_id": "fal-ai/veo3/fast"},
             }
         ],
     )
@@ -429,12 +429,12 @@ def test_fal_status_endpoint_returns_logs_and_result(monkeypatch):
     assert resp.status_code == 200
     payload = resp.get_json()
     assert payload["request_id"] == "req-200"
-    assert payload["model_id"] == "fal-ai/infinitalk/single-text"
+    assert payload["model_id"] == "fal-ai/veo3/fast"
     assert payload["status_upper"] == "SUCCESS"
     assert payload["logs"] == ["Retry attempt #1", "Retry attempt #2"]
     assert payload["video"]["url"] == "https://cdn.example.com/video.mp4"
-    assert calls["status"] == ("fal-ai/infinitalk/single-text", "req-200", True)
-    assert calls["result"] == ("fal-ai/infinitalk/single-text", "req-200")
+    assert calls["status"] == ("fal-ai/veo3/fast", "req-200", True)
+    assert calls["result"] == ("fal-ai/veo3/fast", "req-200")
 
 
 def test_fal_status_missing_job(monkeypatch):

--- a/src/tests/test_fal.py
+++ b/src/tests/test_fal.py
@@ -64,7 +64,7 @@ def test_submit_job_fal(monkeypatch):
 
     body = {
         "user_id": 1,
-        "model_id": "fal-ai/infinitalk/single-text",
+        "model_id": "fal-ai/veo3/fast",
         "prompt": "An elderly man with a white beard and headphones records audio with a microphone. He appears engaged and expressive, suggesting a podcast or voiceover.",
         "text_input": "Spend more time with people who make you feel alive, and less with things that drain your soul.",
         "image_url": "https://v3.fal.media/files/panda/HuM21CXMf0q7OO2zbvwhV_c4533aada79a495b90e50e32dc9b83a8.png",
@@ -87,7 +87,7 @@ def test_submit_job_fal(monkeypatch):
     inserts = [rec for rec in dummy_supabase.records if rec.op == "insert" and rec.table == "jobs"]
     assert inserts and inserts[0].payload["prompt"] == dummy_material.animation_prompt
     params = inserts[0].payload["params"]
-    assert params["model_id"] == "fal-ai/infinitalk/single-text"
+    assert params["model_id"] == "fal-ai/veo3/fast"
     assert params["fal_input"] == captured["payload"]
     assert params["course_material"]["summary"] == dummy_material.script
     assert params["course_material"]["keywords"] == dummy_material.keywords
@@ -96,7 +96,7 @@ def test_submit_job_fal(monkeypatch):
     updates = [rec for rec in dummy_supabase.records if rec.op == "update" and rec.table == "jobs"]
     assert any(rec.payload.get("external_job_id") == "req_123" for rec in updates)
 
-    assert captured["model_id"] == "fal-ai/infinitalk/single-text"
+    assert captured["model_id"] == "fal-ai/veo3/fast"
     assert captured["payload"] == {
         "prompt": dummy_material.animation_prompt,
         "text_input": dummy_material.script,

--- a/src/tests/test_fal_client.py
+++ b/src/tests/test_fal_client.py
@@ -53,7 +53,7 @@ def anyio_backend():
 
 def test_submit_text2video_flattens_payload(capture_post):
     req_id = fal_client.submit_text2video(
-        "fal-ai/infinitalk/single-text",
+        "fal-ai/veo3/fast",
         {
             "prompt": "hello",
             "voice": "Brian",
@@ -73,7 +73,7 @@ def test_submit_text2video_flattens_payload(capture_post):
 
 def test_submit_text2video_accepts_string_input(capture_post):
     fal_client.submit_text2video(
-        "fal-ai/infinitalk/single-text",
+        "fal-ai/veo3/fast",
         "a smiling teacher",
     )
 
@@ -130,7 +130,7 @@ def test_get_status_with_logs(monkeypatch):
     monkeypatch.setattr(fal_client.requests, "get", fake_get)
 
     status = fal_client.get_status(
-        "fal-ai/infinitalk/single-text", "req-99", with_logs=True
+        "fal-ai/veo3/fast", "req-99", with_logs=True
     )
 
     assert captured["params"] == {"logs": "true"}

--- a/src/tests/test_worker.py
+++ b/src/tests/test_worker.py
@@ -53,7 +53,7 @@ def test_process_video_job_inserts_file(monkeypatch):
                 "user_id": 7,
                 "prompt": fal_input_payload["prompt"],
                 "params": {
-                    "model_id": "fal-ai/infinitalk/single-text",
+                    "model_id": "fal-ai/veo3/fast",
                     "fal_input": fal_input_payload,
                 },
             }
@@ -91,9 +91,9 @@ def test_process_video_job_inserts_file(monkeypatch):
     assert any(rec.payload.get("external_job_id") == "abc123" for rec in updates)
     assert any(rec.payload.get("status") == "succeeded" for rec in updates)
 
-    assert submitted["args"] == ("fal-ai/infinitalk/single-text",)
+    assert submitted["args"] == ("fal-ai/veo3/fast",)
     assert submitted["kwargs"]["arguments"] == fal_input_payload
-    assert result_calls == [("fal-ai/infinitalk/single-text", "abc123")]
+    assert result_calls == [("fal-ai/veo3/fast", "abc123")]
 
 
 def _queue_single_job(dummy_supabase, fal_input_payload):
@@ -105,7 +105,7 @@ def _queue_single_job(dummy_supabase, fal_input_payload):
                 "user_id": 7,
                 "prompt": fal_input_payload["prompt"],
                 "params": {
-                    "model_id": "fal-ai/infinitalk/single-text",
+                    "model_id": "fal-ai/veo3/fast",
                     "fal_input": fal_input_payload,
                 },
             }

--- a/worker.py
+++ b/worker.py
@@ -42,7 +42,7 @@ if SUPABASE_URL and SUPABASE_KEY:
 
 
 DEFAULT_FAL_MODEL_ID = os.getenv(
-    "MODEL_DEFAULT", "fal-ai/infinitalk/single-text"
+    "MODEL_DEFAULT", "fal-ai/veo3/fast"
 )
 
 


### PR DESCRIPTION
## Summary
- set the Flask app and Celery worker defaults to use the `fal-ai/veo3/fast` model
- update helper scripts and tests to expect the new model identifier

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9cd1a38e08327a750294c168a4e7a