### PR TITLE
Ajout des supports markdown pour la présentation infrastructure data

### DIFF
--- a/docs/powerpoint/01-titre-contexte.md
+++ b/docs/powerpoint/01-titre-contexte.md
@@ -1,0 +1,8 @@
+# Titre & Contexte
+
+- Vision d'ensemble de l'infrastructure data
+  Présenter l'architecture couvrant la génération vidéo, le stockage, la supervision, les dashboards, l'administration et les capacités analytiques, afin de montrer la portée transverse du projet.
+- Objectifs et valeur métier
+  Expliquer pourquoi industrialiser cette infrastructure est critique pour fiabiliser la production vidéo, accélérer l'innovation et soutenir la croissance.
+- État actuel
+  Décrire les briques déjà en place, leurs limites et les opportunités d'amélioration à court terme.

--- a/docs/powerpoint/02-besoins-volumetrie.md
+++ b/docs/powerpoint/02-besoins-volumetrie.md
@@ -1,0 +1,8 @@
+# Besoins métiers & volumétrie (C4.1.1)
+
+- Parties prenantes et usages
+  Identifier les équipes produit, créatives, marketing et support, préciser leurs parcours clés et les informations qu'elles attendent de l'infrastructure data.
+- Volumes et performances cibles
+  Estimer les jobs vidéo quotidiens, la taille des médias, le volume des métadonnées et des logs, puis aligner les objectifs de latence, disponibilité et fiabilité.
+- Contraintes et existant
+  Synthétiser les limites budgétaires, de sécurité, de conformité et de planning, ainsi que les technologies déjà en place et leurs lacunes.

--- a/docs/powerpoint/03-composants-technologies.md
+++ b/docs/powerpoint/03-composants-technologies.md
@@ -1,0 +1,8 @@
+# Composants & technologies (C4.1.2)
+
+- Architecture cible
+  Décrire la répartition cloud/hybride, les besoins GPU, les briques de stockage et les interconnexions nécessaires pour soutenir la génération vidéo.
+- Composants clés évalués
+  Comparer data lake, data warehouse, stockage objet, CDN, API, pipelines d'ingestion, outils BI et orchestrateurs afin de justifier les choix retenus.
+- Coûts et points de vigilance
+  Donner des ordres de grandeur budgétaires et souligner les risques de vendor lock-in, les efforts d'exploitation et les exigences de sécurité.

--- a/docs/powerpoint/04-schema-donnees.md
+++ b/docs/powerpoint/04-schema-donnees.md
@@ -1,0 +1,8 @@
+# Schéma de données (C4.2.1)
+
+- Typologie et structure des données
+  Lister les prompts, logs, métriques, vidéos générées, métadonnées utilisateur et informations de coûts en précisant leur format et niveau de structuration.
+- Modélisation et accès
+  Décrire les relations entre utilisateurs, jobs, ressources stockées et coûts, puis les modes de consultation temps réel ou historique via API et dashboards.
+- Gouvernance et performance
+  Exposer les règles de sécurité, l'anonymisation, les droits d'accès et les stratégies d'indexation nécessaires pour garantir rapidité et conformité.

--- a/docs/powerpoint/05-pipelines-traitement.md
+++ b/docs/powerpoint/05-pipelines-traitement.md
@@ -1,0 +1,8 @@
+# Pipelines & traitement des données (C4.2.2)
+
+- Chaîne de valeur des données
+  Détailler le parcours collecte → transformation → stockage → consommation et préciser les points de contrôle qualité.
+- Modes de traitement
+  Contraster les flux temps réel, streaming asynchrone et batch, en indiquant les technologies de files d'attente et les cas d'usage associés.
+- Orchestration et automatisation
+  Présenter les outils comme Airflow ou équivalents, la gestion des dépendances, la distribution de charge (ex : Spark) et les transformations automatisées.

--- a/docs/powerpoint/06-cicd-mise-en-production.md
+++ b/docs/powerpoint/06-cicd-mise-en-production.md
@@ -1,0 +1,8 @@
+# CI/CD & mise en production (C4.2.3)
+
+- Intégration continue
+  Décrire la stratégie de tests unitaires, d'intégration et de validation de pipelines pour garantir la qualité des livrables data.
+- Déploiement continu
+  Préciser la gestion des releases des API, des microservices, de l'infrastructure et des composants de monitoring avec traçabilité.
+- Configuration et rollback
+  Expliquer l'usage de Docker, l'organisation dev/staging/prod, la gestion des secrets et les procédures de retour arrière en cas d'anomalie.

--- a/docs/powerpoint/07-supervision-alertes.md
+++ b/docs/powerpoint/07-supervision-alertes.md
@@ -1,0 +1,8 @@
+# Supervision & alertes (C4.3.1)
+
+- Indicateurs et visibilité
+  Lister les métriques critiques comme les taux d'erreurs, la latence, l'utilisation GPU, les coûts et la disponibilité côté utilisateurs et administrateurs.
+- Outils et tableaux de bord
+  Décrire la pile monitoring retenue (Prometheus, Grafana, services cloud) et la manière de présenter les vues adaptées à chaque profil.
+- Alerting et responsabilités
+  Définir les seuils, les canaux de notification, l'escalade et la répartition des rôles pour garantir une réponse rapide.

--- a/docs/powerpoint/08-exploitation-maintenance.md
+++ b/docs/powerpoint/08-exploitation-maintenance.md
@@ -1,0 +1,8 @@
+# Exploitation & maintenance (C4.3.2)
+
+- Plan de maintenance
+  Décrire la feuille de route des mises à jour, la maintenance préventive et les contrôles réguliers de qualité de service.
+- Gestion des incidents et résilience
+  Préciser les procédures d'escalade, les rôles mobilisés, la communication et les stratégies de sauvegarde, redondance et restauration.
+- Sécurité et maîtrise des coûts
+  Rappeler la gestion des certificats, des accès, des audits réguliers et le suivi budgétaire de l'exploitation.

--- a/docs/powerpoint/09-documentation.md
+++ b/docs/powerpoint/09-documentation.md
@@ -1,0 +1,8 @@
+# Documentation (C4.3.3)
+
+- Typologie documentaire
+  Lister les spécifications fonctionnelles et techniques, la documentation API, les guides utilisateurs et opérateurs.
+- Publics et contenu
+  Associer chaque type de document aux audiences (développeurs, exploitation, support, décisionnaires) et préciser les informations attendues.
+- Gestion et diffusion
+  Décrire l'organisation du versioning, les outils de stockage collaboratif et les processus de revue documentaire.

--- a/docs/powerpoint/10-recette-tests.md
+++ b/docs/powerpoint/10-recette-tests.md
@@ -1,0 +1,8 @@
+# Recette & tests (C4.4.1)
+
+- Parcours fonctionnels et sécurité
+  Décrire les scénarios de bout en bout de la soumission de prompt à la récupération vidéo, ainsi que les tests de permissions et de protection des accès.
+- Performance et robustesse
+  Détailer les campagnes de charge, de montée en charge et de validation de l'intégrité des données et métadonnées.
+- Critères de réussite
+  Formaliser les seuils d'acceptation, les KPI attendus et les livrables nécessaires à la validation métier.

--- a/docs/powerpoint/11-incident-resolution.md
+++ b/docs/powerpoint/11-incident-resolution.md
@@ -1,0 +1,8 @@
+# Incident & résolution (C4.4.2)
+
+- Cas d'incident représentatif
+  Illustrer un scénario tel qu'une panne GPU, un job bloqué ou une URL non générée et son impact sur la chaîne de valeur.
+- Diagnostic et remédiation
+  Détailler la collecte d'informations, la reproduction, l'analyse des causes racines et les correctifs déployés incluant le monitoring renforcé.
+- Communication et retour d'expérience
+  Expliquer comment informer utilisateurs et parties prenantes, capitaliser les enseignements et mettre en place des mesures préventives.

--- a/docs/powerpoint/12-synthese-roadmap.md
+++ b/docs/powerpoint/12-synthese-roadmap.md
@@ -1,0 +1,8 @@
+# Synthèse & roadmap
+
+- Décisions structurantes
+  Résumer les choix d'architecture, de composants, de modèle de données et de pipelines retenus pour servir la stratégie data vidéo.
+- Jalons et priorités
+  Décrire les étapes de déploiement, les dépendances majeures, les ressources nécessaires et les priorités de livraison.
+- Risques et prochaines actions
+  Mettre en avant les risques résiduels, les points de vigilance et les actions immédiates à lancer, puis ouvrir la discussion.


### PR DESCRIPTION
## Summary
- Création du dossier `docs/powerpoint` contenant douze fiches Markdown, chacune dédiée à une diapositive du support de présentation (contexte, besoins, architecture, données, pipelines, CI/CD, supervision, exploitation, documentation, tests, incidents et roadmap).

## Testing
- Not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68c9ec20d65c832781de239e85571669