### PR TITLE
Add monitoring overview web page

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -10,6 +10,7 @@
     <div class="max-w-6xl mx-auto flex items-center justify-between p-4">
       <a href="/" class="text-xl font-semibold tracking-wide">AI Video</a>
       <div class="space-x-4 text-sm">
+        <a href="/monitoring" class="hover:text-teal-300">Supervision</a>
         {% if session.get('user_id') %}
         <a href="/dashboard" class="hover:text-teal-300">Dashboard</a>
         {% if session.get('role') == 'admin' %}

--- a/src/templates/monitoring.html
+++ b/src/templates/monitoring.html
@@ -1,0 +1,94 @@
+{% extends "base.html" %}
+{% block title %}Supervision & alertes{% endblock %}
+{% block content %}
+<section class="space-y-8">
+  <header class="text-center space-y-2">
+    <h1 class="text-3xl font-bold text-teal-300">Supervision de la plateforme DATA</h1>
+    <p class="text-slate-300 max-w-3xl mx-auto">
+      Cette page synthétise les indicateurs clés, les outils et les alertes mis en place pour garantir le bon fonctionnement de notre architecture DATA.
+    </p>
+  </header>
+
+  <div class="grid gap-6 md:grid-cols-2">
+    <article class="bg-slate-900/70 border border-slate-700 rounded-xl p-6 shadow-lg shadow-slate-900/40">
+      <h2 class="text-xl font-semibold text-teal-200 mb-4">Objectifs de supervision</h2>
+      <ul class="space-y-3 text-sm leading-relaxed text-slate-200">
+        {% for goal in data.objectives %}
+        <li class="flex gap-3">
+          <span class="text-teal-400">•</span>
+          <span>{{ goal }}</span>
+        </li>
+        {% endfor %}
+      </ul>
+    </article>
+
+    <article class="bg-slate-900/70 border border-slate-700 rounded-xl p-6 shadow-lg shadow-slate-900/40">
+      <h2 class="text-xl font-semibold text-teal-200 mb-4">Composants suivis</h2>
+      <ul class="space-y-3 text-sm leading-relaxed text-slate-200">
+        {% for component in data.components %}
+        <li>
+          <h3 class="font-semibold text-slate-100">{{ component.name }}</h3>
+          <p class="text-slate-300">{{ component.description }}</p>
+        </li>
+        {% endfor %}
+      </ul>
+    </article>
+  </div>
+
+  <section class="bg-slate-900/70 border border-slate-700 rounded-xl p-6 shadow-lg shadow-slate-900/40">
+    <h2 class="text-xl font-semibold text-teal-200 mb-4">Indicateurs surveillés</h2>
+    <div class="grid gap-4 md:grid-cols-3">
+      {% for metric in data.metrics %}
+      <div class="bg-slate-900 border border-slate-800 rounded-lg p-4">
+        <h3 class="font-semibold text-slate-100">{{ metric.name }}</h3>
+        <p class="text-sm text-slate-300">{{ metric.description }}</p>
+        {% if metric.threshold %}
+        <p class="text-xs text-amber-300 mt-2">Seuil d'alerte : {{ metric.threshold }}</p>
+        {% endif %}
+      </div>
+      {% endfor %}
+    </div>
+  </section>
+
+  <section class="grid gap-6 md:grid-cols-2">
+    <article class="bg-slate-900/70 border border-slate-700 rounded-xl p-6 shadow-lg shadow-slate-900/40">
+      <h2 class="text-xl font-semibold text-teal-200 mb-4">Outils et configuration</h2>
+      <ul class="space-y-3 text-sm text-slate-200">
+        {% for tool in data.tools %}
+        <li>
+          <h3 class="font-semibold text-slate-100">{{ tool.name }}</h3>
+          <p class="text-slate-300">{{ tool.role }}</p>
+          {% if tool.details %}
+          <p class="text-xs text-slate-400">{{ tool.details }}</p>
+          {% endif %}
+        </li>
+        {% endfor %}
+      </ul>
+    </article>
+
+    <article class="bg-slate-900/70 border border-slate-700 rounded-xl p-6 shadow-lg shadow-slate-900/40">
+      <h2 class="text-xl font-semibold text-teal-200 mb-4">Alertes & escalade</h2>
+      <ul class="space-y-3 text-sm text-slate-200">
+        {% for alert in data.alerts %}
+        <li>
+          <h3 class="font-semibold text-slate-100">{{ alert.trigger }}</h3>
+          <p class="text-slate-300">{{ alert.action }}</p>
+        </li>
+        {% endfor %}
+      </ul>
+    </article>
+  </section>
+
+  <section class="bg-slate-900/70 border border-slate-700 rounded-xl p-6 shadow-lg shadow-slate-900/40">
+    <h2 class="text-xl font-semibold text-teal-200 mb-4">Visualisations disponibles</h2>
+    <div class="grid gap-4 md:grid-cols-2">
+      {% for viz in data.visualisations %}
+      <div class="bg-slate-900 border border-slate-800 rounded-lg p-4">
+        <h3 class="font-semibold text-slate-100">{{ viz.name }}</h3>
+        <p class="text-sm text-slate-300">{{ viz.description }}</p>
+      </div>
+      {% endfor %}
+    </div>
+  </section>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a navigation entry to access the monitoring overview
- expose a new Flask route that serves a supervision dashboard
- create a Tailwind-based template presenting monitored indicators, tooling and alerts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca1edbc4948327afee90cc257db006