### PR TITLE
Fix monitoring jobs query for schemas without created_at

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -283,6 +283,7 @@ def _aggregate_job_metrics(rows: Sequence[Mapping[str, Any]] | Sequence[dict[str
             row.get("finished_at")
             or row.get("created_at")
             or row.get("submitted_at")
+            or row.get("started_at")
             or row.get("updated_at")
         )
         ts = _parse_timestamp(ts_value)
@@ -1360,8 +1361,8 @@ def monitoring_data():
     try:
         job_res = (
             supabase.table("jobs")
-            .select("status, created_at, submitted_at, finished_at, updated_at")
-            .order("created_at", desc=True)
+            .select("status, submitted_at, started_at, finished_at, updated_at")
+            .order("submitted_at", desc=True)
             .limit(500)
             .execute()
         )


### PR DESCRIPTION
## Summary
- avoid relying on a non-existent jobs.created_at column when loading monitoring metrics
- fall back to started_at timestamps when aggregating job metrics

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ca3b6cd81883278c4f3b5fcb2dd3f5