### PR TITLE
Handle monitoring query without jobs.updated_at column

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1361,7 +1361,7 @@ def monitoring_data():
     try:
         job_res = (
             supabase.table("jobs")
-            .select("status, submitted_at, started_at, finished_at, updated_at")
+            .select("status, submitted_at, started_at, finished_at")
             .order("submitted_at", desc=True)
             .limit(500)
             .execute()


### PR DESCRIPTION
## Summary
- stop requesting the optional updated_at field when loading recent jobs for monitoring
- avoid Supabase errors when the jobs table schema does not include updated_at

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca3e854a2083278d1cd1dd0605cfdc