### PR TITLE
Add admin email alert trigger

### DIFF
--- a/src/templates/admin_dashboard.html
+++ b/src/templates/admin_dashboard.html
@@ -3,7 +3,8 @@
 {% block content %}
 <div class="space-y-8">
   <h1 class="text-3xl font-semibold text-center">Admin Dashboard</h1>
-  <div class="text-right">
+  <div class="flex justify-end gap-3">
+    <button id="send-alert-button" class="px-4 py-2 rounded bg-rose-500 hover:bg-rose-400 text-slate-900 font-semibold">Envoyer une alerte e-mail</button>
     <button id="refresh-admin" class="px-4 py-2 rounded bg-teal-500 hover:bg-teal-400 text-slate-900 font-semibold">Refresh Data</button>
   </div>
   <section>
@@ -187,5 +188,35 @@ async function loadAdmin() {
 document.addEventListener('DOMContentLoaded', loadAdmin);
 
 document.getElementById('refresh-admin').addEventListener('click', loadAdmin);
+
+const alertButton = document.getElementById('send-alert-button');
+if (alertButton) {
+  const defaultLabel = alertButton.textContent;
+  alertButton.addEventListener('click', async () => {
+    if (!window.confirm("Confirmer l'envoi d'une alerte e-mail ?")) {
+      return;
+    }
+    alertButton.disabled = true;
+    alertButton.textContent = 'Envoi en cours…';
+    try {
+      const resp = await fetch('/admin/send_alert', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({})
+      });
+      const data = await resp.json();
+      if (!resp.ok) {
+        throw new Error(data.error || 'Erreur inconnue');
+      }
+      const recipient = data.recipient || 'administrateur';
+      alert(`Alerte envoyée à ${recipient}.`);
+    } catch (error) {
+      alert(`Impossible d'envoyer l'alerte : ${error.message}`);
+    } finally {
+      alertButton.disabled = false;
+      alertButton.textContent = defaultLabel;
+    }
+  });
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add SMTP configuration helpers and alert email sender utility in the Flask app
- expose a protected /admin/send_alert endpoint that sends the configured alert email
- update the admin dashboard to provide a button for triggering the alert and add regression tests for the new route

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca446eca9883279cdf3082828b4d1a